### PR TITLE
Update article on `std::array`

### DIFF
--- a/wiki_articles/std_array.md
+++ b/wiki_articles/std_array.md
@@ -4,7 +4,7 @@ C-style arrays have important shortcomings:<br/>
 
 :no_entry: cannot be returned from functions<br>
 :no_entry: cannot be assigned with `=`<br>
-:warning: cannot be compared with `==`, `<` etc. (it'd be pointer comparison)
+:no_entry: cannot be compared with `==`, `<` etc. (it'd be pointer comparison)<br>
 :no_entry: can only be initialized via `""`, `{}`, or *[default initialization][1]*<br>
 :warning: might implicitly [decay to pointers][2]; C arrays are not passed by value to functions<br>
 :warning: might be [variable-length arrays][3] (VLAs), if the developer makes a mistake

--- a/wiki_articles/std_array.md
+++ b/wiki_articles/std_array.md
@@ -3,9 +3,10 @@
 C-style arrays have important shortcomings:<br/>
 
 :no_entry: cannot be returned from functions<br>
-:no_entry: are not assignable with `=`<br>
+:no_entry: cannot be assigned with `=`<br>
+:warning: cannot be compared with `==`, `<` etc. (it'd be pointer comparison)
 :no_entry: can only be initialized via `""`, `{}`, or *[default initialization][1]*<br>
-:warning: might implicitly [decay to pointers][2], notably C arrays are not passed by value to functions<br>
+:warning: might implicitly [decay to pointers][2]; C arrays are not passed by value to functions<br>
 :warning: might be [variable-length arrays][3] (VLAs), if the developer makes a mistake
 
 [1]: https://en.cppreference.com/w/cpp/language/default_initialization


### PR DESCRIPTION
The warning bullet on decay currently spans two lines, which is bad.

Also this adds another `:no_entry:` bullet which informs about a likely bug. Comparisons between arrays have been deprecated in C++23 and are likely going to be removed in C++26. See https://stackoverflow.com/q/12866413/5740428