### PR TITLE
component to check for c++ code in c-help-text channel

### DIFF
--- a/src/components/c-help-redirect.ts
+++ b/src/components/c-help-redirect.ts
@@ -52,7 +52,7 @@ export default class CHelpRedirect extends BotComponent {
         );
     }
 
-    async is_new_member(message: Discord.Message) {
+    async is_not_new_member(message: Discord.Message) {
         let member: Discord.GuildMember;
         if (message.member == null) {
             try {
@@ -65,7 +65,7 @@ export default class CHelpRedirect extends BotComponent {
             member = message.member;
         }
         assert(member.joinedTimestamp != null);
-        return Date.now() - member.joinedTimestamp <= 7 * DAY;
+        return Date.now() - member.joinedTimestamp >= 7 * DAY;
     }
 
     check_message(message: Discord.Message): boolean {
@@ -126,8 +126,7 @@ export default class CHelpRedirect extends BotComponent {
         }
 
         //only bother new members
-        if(await this.is_new_member(message))
-        {
+        if(await this.is_not_new_member(message)) {
             return;
         }
 

--- a/src/components/c-help-redirect.ts
+++ b/src/components/c-help-redirect.ts
@@ -10,269 +10,249 @@ import { M } from "../utils/debugging-and-logging.js";
 const code_block_start = "```";
 
 const cpp_keywords = [
-  "std::", //just :: would work too, this is slightly less prone to false positives
-  "using namespace ",
-  "class ",
-  "typename ",
-  "template",
-  "virtual ",
-  "dynamic_cast",
-  "static_cast",
-  "const_cast",
-  "reinterpret_cast",
-  "= new ", //too common to include just "new"
-  //"delete ", //too common
-  "delete[]",
-  "public:",
-  "protected:",
-  "private:",
+    "std::", //just :: would work too, this is slightly less prone to false positives
+    "using namespace ",
+    "class ",
+    "typename ",
+    "template",
+    "virtual ",
+    "dynamic_cast",
+    "static_cast",
+    "const_cast",
+    "reinterpret_cast",
+    "= new ", //too common to include just "new"
+    //"delete ", //too common
+    "delete[]",
+    "public:",
+    "protected:",
+    "private:",
 ];
 
 const not_c_keywords = [
-  "explicit",
-  "mutable",
-  "final",
-  "try",
-  "catch",
-  "throw",
-  "operator", //possibly list all operator+ etc. to be on the safe side
-  "cout<<",
-  "cout <<",
-  "cin>>",
-  "cin >>",
-  "<iostream>",
-  "<cstdio>",
+    "explicit",
+    "mutable",
+    "final",
+    "try",
+    "catch",
+    "throw",
+    "operator", //possibly list all operator+ etc. to be on the safe side
+    "cout<<",
+    "cout <<",
+    "cin>>",
+    "cin >>",
+    "<iostream>",
+    "<cstdio>",
 ];
 
 const maybe_c_keywords = [
-  "printf",
-  "scanf",
-  "<stdio.h>",
-  "<stdlib.h>",
-  "<math.h>",
-  "malloc",
-  "calloc",
-  "realloc",
-  "free(", //too common to include just "free"
+    "printf",
+    "scanf",
+    "<stdio.h>",
+    "<stdlib.h>",
+    "<math.h>",
+    "malloc",
+    "calloc",
+    "realloc",
+    "free(", //too common to include just "free"
 ];
 
 /**
  * Checks for cpp code in #c-help-text and suggests #cpp-help-text instead, and vice versa
  */
 export default class CHelpRedirect extends BotComponent {
-  constructor(wheatley: Wheatley) {
-    super(wheatley);
+    constructor(wheatley: Wheatley) {
+        super(wheatley);
 
-    this.add_command(
-      new TextBasedCommandBuilder("not-c")
-        .set_description("Mark C++ code in the C help channel")
-        .add_user_option({
-          title: "user",
-          description: "User who posted the code",
-          required: false,
-        })
-        .set_handler(this.not_c.bind(this)),
-    );
+        this.add_command(
+            new TextBasedCommandBuilder("not-c")
+                .set_description("Mark C++ code in the C help channel")
+                .add_user_option({
+                    title: "user",
+                    description: "User who posted the code",
+                    required: false,
+                })
+                .set_handler(this.not_c.bind(this)),
+        );
 
-    this.add_command(
-      new TextBasedCommandBuilder("not-cpp")
-        .set_description("Mark C code in the C++ help channel")
-        .add_user_option({
-          title: "user",
-          description: "User who posted the code",
-          required: false,
-        })
-        .set_handler(this.not_cpp.bind(this)),
-    );
-  }
+        this.add_command(
+            new TextBasedCommandBuilder("not-cpp")
+                .set_description("Mark C code in the C++ help channel")
+                .add_user_option({
+                    title: "user",
+                    description: "User who posted the code",
+                    required: false,
+                })
+                .set_handler(this.not_cpp.bind(this)),
+        );
+    }
 
-  async is_not_new_member(message: Discord.Message) {
-    let member: Discord.GuildMember;
-    if (message.member == null) {
-      try {
-        member = await message.guild!.members.fetch(message.author.id);
-      } catch (error) {
-        M.warn("Failed to get user", message.author.id);
+    async is_not_new_member(message: Discord.Message) {
+        let member: Discord.GuildMember;
+        if (message.member == null) {
+            try {
+                member = await message.guild!.members.fetch(message.author.id);
+            } catch (error) {
+                M.warn("Failed to get user", message.author.id);
+                return false;
+            }
+        } else {
+            member = message.member;
+        }
+        assert(member.joinedTimestamp != null);
+        return Date.now() - member.joinedTimestamp >= 7 * DAY;
+    }
+
+    check_message_for_cpp_code(message: Discord.Message): boolean {
+        if (!message.content.includes(code_block_start)) {
+            // to avoid false positives, only check inside code blocks
+            return false;
+        }
+
+        let text = message.content;
+
+        while (text.search(code_block_start) > -1) {
+            const start = text.search(code_block_start);
+            const end = text.substring(start + code_block_start.length).search(code_block_start);
+            const block = text.substring(start + code_block_start.length, start + code_block_start.length + end);
+
+            for (const keyword of cpp_keywords) {
+                if (block.includes(keyword)) {
+                    return true;
+                }
+            }
+
+            text = text.substring(start + code_block_start.length + end + code_block_start.length);
+        }
         return false;
-      }
-    } else {
-      member = message.member;
-    }
-    assert(member.joinedTimestamp != null);
-    return Date.now() - member.joinedTimestamp >= 7 * DAY;
-  }
-
-  check_message_for_cpp_code(message: Discord.Message): boolean {
-    if (!message.content.includes(code_block_start)) {
-      // to avoid false positives, only check inside code blocks
-      return false;
     }
 
-    let text = message.content;
-
-    while (text.search(code_block_start) > -1) {
-      const start = text.search(code_block_start);
-      const end = text
-        .substring(start + code_block_start.length)
-        .search(code_block_start);
-      const block = text.substring(
-        start + code_block_start.length,
-        start + code_block_start.length + end,
-      );
-
-      for (const keyword of cpp_keywords) {
-        if (block.includes(keyword)) {
-          return true;
+    check_message_for_c_code(message: Discord.Message): boolean {
+        if (!message.content.includes(code_block_start)) {
+            // to avoid false positives, only check inside code blocks
+            return false;
         }
-      }
 
-      text = text.substring(
-        start + code_block_start.length + end + code_block_start.length,
-      );
-    }
-    return false;
-  }
+        let text = message.content;
 
-  check_message_for_c_code(message: Discord.Message): boolean {
-    if (!message.content.includes(code_block_start)) {
-      // to avoid false positives, only check inside code blocks
-      return false;
-    }
+        while (text.search(code_block_start) > -1) {
+            const start = text.search(code_block_start);
+            const end = text.substring(start + code_block_start.length).search(code_block_start);
+            const block = text.substring(start + code_block_start.length, start + code_block_start.length + end);
 
-    let text = message.content;
+            //for C code, the block must not have any C++ keywords
+            //including inconclusive keywords
+            //and have some C keyword
 
-    while (text.search(code_block_start) > -1) {
-      const start = text.search(code_block_start);
-      const end = text
-        .substring(start + code_block_start.length)
-        .search(code_block_start);
-      const block = text.substring(
-        start + code_block_start.length,
-        start + code_block_start.length + end,
-      );
+            let c_code_found = false;
+            let cpp_code_found = false;
 
-      //for C code, the block must not have any C++ keywords
-      //including inconclusive keywords
-      //and have some C keyword
+            for (const keyword of cpp_keywords) {
+                if (block.includes(keyword)) {
+                    cpp_code_found = true;
+                }
+            }
 
-      let c_code_found = false;
-      let cpp_code_found = false;
+            for (const keyword of not_c_keywords) {
+                if (block.includes(keyword)) {
+                    cpp_code_found = true;
+                }
+            }
 
-      for (const keyword of cpp_keywords) {
-        if (block.includes(keyword)) {
-          cpp_code_found = true;
+            for (const keyword of maybe_c_keywords) {
+                if (block.includes(keyword)) {
+                    c_code_found = true;
+                }
+            }
+
+            if (c_code_found && !cpp_code_found) {
+                return true;
+            }
+
+            text = text.substring(start + code_block_start.length + end + code_block_start.length);
         }
-      }
+        return false;
+    }
 
-      for (const keyword of not_c_keywords) {
-        if (block.includes(keyword)) {
-          cpp_code_found = true;
+    async not_c(command: TextBasedCommand, user: Discord.User | null) {
+        assert(command.channel);
+        assert(command.channel instanceof Discord.GuildChannel);
+
+        // Only allowed in #c-help-text
+        if (command.channel.id != this.wheatley.channels.c_help_text.id) {
+            await command.reply(`Can only be used in <#${this.wheatley.channels.c_help_text.id}>`, true);
+            return;
         }
-      }
 
-      for (const keyword of maybe_c_keywords) {
-        if (block.includes(keyword)) {
-          c_code_found = true;
+        //for manual triggers, trust the caller and don't check the message
+        //supposedly the automatic check didn't trigger, so checking the message again would fail again
+        if (user) {
+            await command.channel.send(
+                `<@${user.id}> Your code looks like C++ code, but this is a C channel. ` +
+                    `Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
+            );
+        } else {
+            await command.channel.send(
+                `This code looks like C++ code, but this is a C channel. ` +
+                    `Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
+            );
         }
-      }
-
-      if (c_code_found && !cpp_code_found) {
-        return true;
-      }
-
-      text = text.substring(
-        start + code_block_start.length + end + code_block_start.length,
-      );
-    }
-    return false;
-  }
-
-  async not_c(command: TextBasedCommand, user: Discord.User | null) {
-    assert(command.channel);
-    assert(command.channel instanceof Discord.GuildChannel);
-
-    // Only allowed in #c-help-text
-    if (command.channel.id != this.wheatley.channels.c_help_text.id) {
-      await command.reply(
-        `Can only be used in <#${this.wheatley.channels.c_help_text.id}>`,
-        true,
-      );
-      return;
     }
 
-    //for manual triggers, trust the caller and don't check the message
-    //supposedly the automatic check didn't trigger, so checking the message again would fail again
-    if (user) {
-      await command.channel.send(
-        `<@${user.id}> Your code looks like C++ code, but this is a C channel. ` +
-          `Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
-      );
-    } else {
-      await command.channel.send(
-        `This code looks like C++ code, but this is a C channel. ` +
-          `Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
-      );
-    }
-  }
+    async not_cpp(command: TextBasedCommand, user: Discord.User | null) {
+        assert(command.channel);
+        assert(command.channel instanceof Discord.GuildChannel);
 
-  async not_cpp(command: TextBasedCommand, user: Discord.User | null) {
-    assert(command.channel);
-    assert(command.channel instanceof Discord.GuildChannel);
+        // Only allowed in #cpp-help-text
+        if (command.channel.id != this.wheatley.channels.cpp_help_text.id) {
+            await command.reply(`Can only be used in <#${this.wheatley.channels.cpp_help_text.id}>`, true);
+            return;
+        }
 
-    // Only allowed in #cpp-help-text
-    if (command.channel.id != this.wheatley.channels.cpp_help_text.id) {
-      await command.reply(
-        `Can only be used in <#${this.wheatley.channels.cpp_help_text.id}>`,
-        true,
-      );
-      return;
+        //for manual triggers, trust the caller and don't check the message
+        //supposedly the automatic check didn't trigger, so checking the message again would fail again
+        if (user) {
+            await command.channel.send(
+                `<@${user.id}> Your code looks like C code, but this is a C++ channel. ` +
+                    `Did you mean to post in <#${this.wheatley.channels.c_help_text.id}>?`,
+            );
+        } else {
+            await command.channel.send(
+                `This code looks like C code, but this is a C++ channel. ` +
+                    `Did you mean to post in <#${this.wheatley.channels.c_help_text.id}>?`,
+            );
+        }
     }
 
-    //for manual triggers, trust the caller and don't check the message
-    //supposedly the automatic check didn't trigger, so checking the message again would fail again
-    if (user) {
-      await command.channel.send(
-        `<@${user.id}> Your code looks like C code, but this is a C++ channel. ` +
-          `Did you mean to post in <#${this.wheatley.channels.c_help_text.id}>?`,
-      );
-    } else {
-      await command.channel.send(
-        `This code looks like C code, but this is a C++ channel. ` +
-          `Did you mean to post in <#${this.wheatley.channels.c_help_text.id}>?`,
-      );
-    }
-  }
+    override async on_message_create(message: Discord.Message) {
+        // Ignore self, bots, and messages outside TCCPP (e.g. dm's)
+        if (
+            message.author.id == this.wheatley.client.user!.id ||
+            message.author.bot ||
+            message.guildId != this.wheatley.TCCPP.id
+        ) {
+            return;
+        }
 
-  override async on_message_create(message: Discord.Message) {
-    // Ignore self, bots, and messages outside TCCPP (e.g. dm's)
-    if (
-      message.author.id == this.wheatley.client.user!.id ||
-      message.author.bot ||
-      message.guildId != this.wheatley.TCCPP.id
-    ) {
-      return;
-    }
+        //only auto-check new members
+        if (await this.is_not_new_member(message)) {
+            return;
+        }
 
-    //only auto-check new members
-    if (await this.is_not_new_member(message)) {
-      return;
+        // Only check messages in help-text channels
+        if (message.channel.id == this.wheatley.channels.c_help_text.id) {
+            if (this.check_message_for_cpp_code(message)) {
+                await message.reply(
+                    `<@${message.author.id}> Your code looks like C++ code, but this is a C channel.` +
+                        `Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
+                );
+            }
+        } else if (message.channel.id == this.wheatley.channels.cpp_help_text.id) {
+            if (this.check_message_for_c_code(message)) {
+                await message.reply(
+                    `<@${message.author.id}> Your code looks like C code, but this is a C++ channel.` +
+                        `Did you mean to post in <#${this.wheatley.channels.c_help_text.id}>?`,
+                );
+            }
+        }
     }
-
-    // Only check messages in help-text channels
-    if (message.channel.id == this.wheatley.channels.c_help_text.id) {
-      if (this.check_message_for_cpp_code(message)) {
-        await message.reply(
-          `<@${message.author.id}> Your code looks like C++ code, but this is a C channel.` +
-            `Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
-        );
-      }
-    } else if (message.channel.id == this.wheatley.channels.cpp_help_text.id) {
-      if (this.check_message_for_c_code(message)) {
-        await message.reply(
-          `<@${message.author.id}> Your code looks like C code, but this is a C++ channel.` +
-            `Did you mean to post in <#${this.wheatley.channels.c_help_text.id}>?`,
-        );
-      }
-    }
-  }
 }

--- a/src/components/c-help-redirect.ts
+++ b/src/components/c-help-redirect.ts
@@ -10,138 +10,148 @@ import { M } from "../utils/debugging-and-logging.js";
 const code_block_start = "```";
 
 const cpp_keywords = [
-    "std::", //just :: would work too, this is slightly less prone to false positives
-    "using namespace ",
-    "class ",
-    "typename ",
-    "template",
-    "virtual ",
-    "dynamic_cast",
-    "static_cast",
-    "const_cast",
-    "reinterpret_cast",
-    "new ",
-    "delete ",
-    "public:",
-    "protected:",
-    "private:",
-    // other cpp-only keywords:
-    //explicit/mutable/final
-    //try/catch/throw
-    //operator
-    //"cout <<" / "cin >>"
-    //true/false
+  "std::", //just :: would work too, this is slightly less prone to false positives
+  "using namespace ",
+  "class ",
+  "typename ",
+  "template",
+  "virtual ",
+  "dynamic_cast",
+  "static_cast",
+  "const_cast",
+  "reinterpret_cast",
+  "new ",
+  "delete ",
+  "public:",
+  "protected:",
+  "private:",
+  // other cpp-only keywords:
+  //explicit/mutable/final
+  //try/catch/throw
+  //operator
+  //"cout <<" / "cin >>"
+  //true/false
 ];
 
 /**
  * Checks for cpp code in #c-help-text and suggests #cpp-help-text instead
  */
 export default class CHelpRedirect extends BotComponent {
-    constructor(wheatley: Wheatley) {
-        super(wheatley);
+  constructor(wheatley: Wheatley) {
+    super(wheatley);
 
-        this.add_command(
-            new TextBasedCommandBuilder("not-c")
-                .set_description("Mark C++ code in the C help channel")
-                .add_user_option({
-                    title: "user",
-                    description: "User who posted the code",
-                    required: false,
-                })
-                .set_handler(this.not_c.bind(this)),
-        );
-    }
+    this.add_command(
+      new TextBasedCommandBuilder("not-c")
+        .set_description("Mark C++ code in the C help channel")
+        .add_user_option({
+          title: "user",
+          description: "User who posted the code",
+          required: false,
+        })
+        .set_handler(this.not_c.bind(this)),
+    );
+  }
 
-    async is_not_new_member(message: Discord.Message) {
-        let member: Discord.GuildMember;
-        if (message.member == null) {
-            try {
-                member = await message.guild!.members.fetch(message.author.id);
-            } catch (error) {
-                M.warn("Failed to get user", message.author.id);
-                return false;
-            }
-        } else {
-            member = message.member;
-        }
-        assert(member.joinedTimestamp != null);
-        return Date.now() - member.joinedTimestamp >= 7 * DAY;
-    }
-
-    check_message(message: Discord.Message): boolean {
-        if (!message.content.includes(code_block_start)) {
-            // to avoid false positives, only check inside code blocks
-            return false;
-        }
-
-        let text = message.content;
-
-        while (text.search(code_block_start) > -1) {
-            const start = text.search(code_block_start);
-            const end = text.substring(start + code_block_start.length).search(code_block_start);
-            const block = text.substring(start + code_block_start.length, start + code_block_start.length + end);
-
-            for (const keyword of cpp_keywords) {
-                if (block.includes(keyword)) {
-                    return true;
-                }
-            }
-
-            text = text.substring(start + code_block_start.length + end + code_block_start.length);
-        }
+  async is_not_new_member(message: Discord.Message) {
+    let member: Discord.GuildMember;
+    if (message.member == null) {
+      try {
+        member = await message.guild!.members.fetch(message.author.id);
+      } catch (error) {
+        M.warn("Failed to get user", message.author.id);
         return false;
+      }
+    } else {
+      member = message.member;
+    }
+    assert(member.joinedTimestamp != null);
+    return Date.now() - member.joinedTimestamp >= 7 * DAY;
+  }
+
+  check_message(message: Discord.Message): boolean {
+    if (!message.content.includes(code_block_start)) {
+      // to avoid false positives, only check inside code blocks
+      return false;
     }
 
-    async not_c(command: TextBasedCommand, user: Discord.User | null) {
-        assert(command.channel);
-        assert(command.channel instanceof Discord.GuildChannel);
+    let text = message.content;
 
-        // Only allowed in #c-help-text
-        if (command.channel.id != this.wheatley.channels.c_help_text.id) {
-            await command.reply(`Can only be used in <#${this.wheatley.channels.c_help_text.id}>`, true);
-            return;
-        }
+    while (text.search(code_block_start) > -1) {
+      const start = text.search(code_block_start);
+      const end = text
+        .substring(start + code_block_start.length)
+        .search(code_block_start);
+      const block = text.substring(
+        start + code_block_start.length,
+        start + code_block_start.length + end,
+      );
 
-        //for manual triggers, trust the caller and don't check the message
-        //supposedly the automatic check didn't trigger, so checking the message again would fail again
-        if (user) {
-            await command.channel.send(
-                `<@${user.id}> Your code looks like C++ code, but this is a C channel. ` +
-                    `Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
-            );
-        } else {
-            await command.channel.send(
-                `This code looks like C++ code, but this is a C channel. ` +
-                    `Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
-            );
+      for (const keyword of cpp_keywords) {
+        if (block.includes(keyword)) {
+          return true;
         }
+      }
+
+      text = text.substring(
+        start + code_block_start.length + end + code_block_start.length,
+      );
+    }
+    return false;
+  }
+
+  async not_c(command: TextBasedCommand, user: Discord.User | null) {
+    assert(command.channel);
+    assert(command.channel instanceof Discord.GuildChannel);
+
+    // Only allowed in #c-help-text
+    if (command.channel.id != this.wheatley.channels.c_help_text.id) {
+      await command.reply(
+        `Can only be used in <#${this.wheatley.channels.c_help_text.id}>`,
+        true,
+      );
+      return;
     }
 
-    override async on_message_create(message: Discord.Message) {
-        // Ignore self, bots, and messages outside TCCPP (e.g. dm's)
-        if (
-            message.author.id == this.wheatley.client.user!.id ||
-            message.author.bot ||
-            message.guildId != this.wheatley.TCCPP.id
-        ) {
-            return;
-        }
-
-        // Only check messages in #c-help-text
-        if (message.channel.id != this.wheatley.channels.c_help_text.id) {
-            return;
-        }
-
-        //only bother new members
-        if(await this.is_not_new_member(message)) {
-            return;
-        }
-
-        if (this.check_message(message)) {
-            await message.reply(
-                `<@${message.author.id}> Your code looks like C++ code, but this is a C channel.` +
-                    `Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
-            );
-        }
+    //for manual triggers, trust the caller and don't check the message
+    //supposedly the automatic check didn't trigger, so checking the message again would fail again
+    if (user) {
+      await command.channel.send(
+        `<@${user.id}> Your code looks like C++ code, but this is a C channel. ` +
+          `Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
+      );
+    } else {
+      await command.channel.send(
+        `This code looks like C++ code, but this is a C channel. ` +
+          `Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
+      );
     }
+  }
+
+  override async on_message_create(message: Discord.Message) {
+    // Ignore self, bots, and messages outside TCCPP (e.g. dm's)
+    if (
+      message.author.id == this.wheatley.client.user!.id ||
+      message.author.bot ||
+      message.guildId != this.wheatley.TCCPP.id
+    ) {
+      return;
+    }
+
+    // Only check messages in #c-help-text
+    if (message.channel.id != this.wheatley.channels.c_help_text.id) {
+      return;
+    }
+
+    //only bother new members
+    if (await this.is_not_new_member(message)) {
+      return;
+    }
+
+    if (this.check_message(message)) {
+      await message.reply(
+        `<@${message.author.id}> Your code looks like C++ code, but this is a C channel.` +
+          `Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
+      );
+    }
+  }
 }

--- a/src/components/c-help-redirect.ts
+++ b/src/components/c-help-redirect.ts
@@ -8,114 +8,110 @@ import { TextBasedCommand } from "../command-abstractions/text-based-command.js"
 const code_block_start = "```";
 
 const cpp_keywords = [
-  "std::", //just :: would work too, this is slightly less prone to false positives
-  "using namespace ",
-  "class ",
-  "typename ",
-  "template",
-  "virtual ",
-  "dynamic_cast",
-  "static_cast",
-  "const_cast",
-  "reinterpret_cast",
-  "new ",
-  "delete ",
-  "public:",
-  "protected:",
-  "private:",
-  // other cpp-only keywords:
-  //explicit/mutable/final
-  //try/catch/throw
-  //operator
-  //"cout <<" / "cin >>"
-  //true/false
+    "std::", //just :: would work too, this is slightly less prone to false positives
+    "using namespace ",
+    "class ",
+    "typename ",
+    "template",
+    "virtual ",
+    "dynamic_cast",
+    "static_cast",
+    "const_cast",
+    "reinterpret_cast",
+    "new ",
+    "delete ",
+    "public:",
+    "protected:",
+    "private:",
+    // other cpp-only keywords:
+    //explicit/mutable/final
+    //try/catch/throw
+    //operator
+    //"cout <<" / "cin >>"
+    //true/false
 ];
 
 /**
  * Checks for cpp code in #c-help-text and suggests #cpp-help-text instead
  */
 export default class CHelpRedirect extends BotComponent {
-  constructor(wheatley: Wheatley) {
-    super(wheatley);
+    constructor(wheatley: Wheatley) {
+        super(wheatley);
 
-    this.add_command(
-      new TextBasedCommandBuilder("not-c")
-        .set_description("Mark C++ code in the C help channel")
-        .add_user_option({
-          title: "user",
-          description: "User who posted the code",
-          required: false,
-        })
-        .set_handler(this.not_c.bind(this)),
-    );
-  }
-
-  check_message(message: Discord.Message): boolean {
-    if (!message.content.includes(code_block_start)) {
-      // to avoid false positives, only check inside code blocks
-      return false;
+        this.add_command(
+            new TextBasedCommandBuilder("not-c")
+                .set_description("Mark C++ code in the C help channel")
+                .add_user_option({
+                    title: "user",
+                    description: "User who posted the code",
+                    required: false,
+                })
+                .set_handler(this.not_c.bind(this)),
+        );
     }
 
-    let text = message.content;
-
-    while (text.search(code_block_start) > -1) {
-      let start = text.search(code_block_start);
-      let end = text
-        .substring(start + code_block_start.length)
-        .search(code_block_start);
-      let block = text.substring(
-        start + code_block_start.length,
-        start + code_block_start.length + end,
-      );
-
-      for (const keyword of cpp_keywords) {
-        if (block.includes(keyword)) {
-          return true;
+    check_message(message: Discord.Message): boolean {
+        if (!message.content.includes(code_block_start)) {
+            // to avoid false positives, only check inside code blocks
+            return false;
         }
-      }
 
-      text = text.substring(
-        start + code_block_start.length + end + code_block_start.length,
-      );
-    }
-    return false;
-  }
+        let text = message.content;
 
-  async not_c(command: TextBasedCommand, user: Discord.User | null) {
-    assert(command.channel);
-    assert(command.channel instanceof Discord.GuildChannel);
-    //for manual triggers, trust the caller and don't check the message
-    //supposedly the automatic check didn't trigger, so checking the message again would fail again
-    if (user) {
-      await command.channel.send(
-        `<@${user.id}> Your code looks like C++ code, but this is a C channel. Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>? `,
-      );
-    } else {
-      await command.channel.send(
-        `This code looks like C++ code, but this is a C channel. Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
-      );
-    }
-  }
+        while (text.search(code_block_start) > -1) {
+            const start = text.search(code_block_start);
+            const end = text.substring(start + code_block_start.length).search(code_block_start);
+            const block = text.substring(start + code_block_start.length, start + code_block_start.length + end);
 
-  override async on_message_create(message: Discord.Message) {
-    // Ignore self, bots, and messages outside TCCPP (e.g. dm's)
-    if (
-      message.author.id == this.wheatley.client.user!.id ||
-      message.author.bot ||
-      message.guildId != this.wheatley.TCCPP.id
-    ) {
-      return;
+            for (const keyword of cpp_keywords) {
+                if (block.includes(keyword)) {
+                    return true;
+                }
+            }
+
+            text = text.substring(start + code_block_start.length + end + code_block_start.length);
+        }
+        return false;
     }
 
-    // Only check messages in #c-help-text
-    if (message.channel.id != this.wheatley.channels.c_help_text.id) {
-      return;
+    async not_c(command: TextBasedCommand, user: Discord.User | null) {
+        assert(command.channel);
+        assert(command.channel instanceof Discord.GuildChannel);
+        //for manual triggers, trust the caller and don't check the message
+        //supposedly the automatic check didn't trigger, so checking the message again would fail again
+        if (user) {
+            await command.channel.send(
+                `<@${user.id}> Your code looks like C++ code, but this is a C channel. ` +
+                    `Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
+            );
+        } else {
+            await command.channel.send(
+                `This code looks like C++ code, but this is a C channel. ` +
+                    `Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
+            );
+        }
     }
 
-    if (this.check_message(message)) {
-      await message.reply(
-        `<@${message.author.id}> Your code looks like C++ code, but this is a C channel. Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
-      );
+    override async on_message_create(message: Discord.Message) {
+        // Ignore self, bots, and messages outside TCCPP (e.g. dm's)
+        if (
+            message.author.id == this.wheatley.client.user!.id ||
+            message.author.bot ||
+            message.guildId != this.wheatley.TCCPP.id
+        ) {
+            return;
+        }
+
+        // Only check messages in #c-help-text
+        if (message.channel.id != this.wheatley.channels.c_help_text.id) {
+            return;
+        }
+
+        if (this.check_message(message)) {
+            await message.reply(
+                `<@${message.author.id}> Your code looks like C++ code, but this is a C channel.` +
+                    `Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
+            );
+        }
     }
-  }
 }

--- a/src/components/c-help-redirect.ts
+++ b/src/components/c-help-redirect.ts
@@ -1,0 +1,111 @@
+import * as Discord from "discord.js";
+import { BotComponent } from "../bot-component.js";
+import { Wheatley } from "../wheatley.js";
+
+const code_block_start = "```";
+
+const cpp_keywords = [
+    "std::",//just :: would work too, this is slightly less prone to false positives
+    "using namespace ",
+    "class ",
+    "typename ",
+    "template",
+    "virtual ",
+    "dynamic_cast",
+    "static_cast",
+    "const_cast",
+    "reinterpret_cast",
+    "new ",
+    "delete ",
+    "public:",
+    "protected:",
+    "private:",
+    // other cpp-only keywords:
+    //explicit/mutable/final
+    //try/catch/throw
+    //operator
+    //"cout <<" / "cin >>"
+    //true/false
+    ];
+
+/**
+ * Checks for cpp code in #c-help-text and suggests #cpp-help-text instead
+ */
+export default class CHelpRedirect extends BotComponent {
+    constructor(wheatley: Wheatley) {
+        super(wheatley);
+
+        this.add_command(
+            new TextBasedCommandBuilder(["not-c"])
+                .set_description(["Mark C++ code in the C help channel"])
+                .add_user_option({
+                    title: "user",
+                    description: "User who posted the code",
+                    required: false,
+                })
+                .set_handler(this.not_c.bind(this)),
+        );
+    }
+
+    check_message(message: Discord.Message) : boolean {
+        if (!message.content.includes(code_block_start)) {
+            // to avoid false positives, only check inside code blocks
+            return false;
+        }
+
+        let text = message.content;
+
+        while(text.search(code_block_start) > -1)
+        {
+            let start = text.search(code_block_start)
+            let end = text.substring(start + code_block_start.length).search(code_block_start)
+            let block = text.substring(start + code_block_start.length, start + code_block_start.length + end)
+
+            for(var keyword of cpp_keywords)
+            {
+                if(block.includes(keyword))
+                {
+                    return true;
+                }
+            }
+
+            text = text.substring(start + code_block_start.length + end + code_block_start.length)
+        }
+        return false;
+    }
+
+    async not_c(command: TextBasedCommand, user: Discord.User | null) {
+        //for manual triggers, trust the caller and don't check the message
+        //supposedly the automatic check didn't trigger, so checking the message again would fail again
+        if(user)
+        {
+            await command.channel.send(`<@${user.id}> Your code looks like C++ code, but this is a C channel. Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>? `);
+        }
+        else
+        {
+            await command.channel.send(`This code looks like C++ code, but this is a C channel. Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`);
+        }
+    }
+
+    override async on_message_create(message: Discord.Message) {
+        // Ignore self, bots, and messages outside TCCPP (e.g. dm's)
+        if (
+            message.author.id == this.wheatley.client.user!.id ||
+            message.author.bot ||
+            message.guildId != this.wheatley.TCCPP.id
+        ) {
+            return;
+        }
+
+        // Only check messages in #c-help-text
+        if (message.channel.id != this.wheatley.channels.c_help_text)
+        {
+            return;
+        }
+
+        if(this.check_message(message))
+        {
+            await message.reply(`<@${message.author.id}> Your code looks like C++ code, but this is a C channel. Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`);
+        }
+    }
+}

--- a/src/components/c-help-redirect.ts
+++ b/src/components/c-help-redirect.ts
@@ -8,109 +8,114 @@ import { TextBasedCommand } from "../command-abstractions/text-based-command.js"
 const code_block_start = "```";
 
 const cpp_keywords = [
-    "std::",//just :: would work too, this is slightly less prone to false positives
-    "using namespace ",
-    "class ",
-    "typename ",
-    "template",
-    "virtual ",
-    "dynamic_cast",
-    "static_cast",
-    "const_cast",
-    "reinterpret_cast",
-    "new ",
-    "delete ",
-    "public:",
-    "protected:",
-    "private:",
-    // other cpp-only keywords:
-    //explicit/mutable/final
-    //try/catch/throw
-    //operator
-    //"cout <<" / "cin >>"
-    //true/false
-    ];
+  "std::", //just :: would work too, this is slightly less prone to false positives
+  "using namespace ",
+  "class ",
+  "typename ",
+  "template",
+  "virtual ",
+  "dynamic_cast",
+  "static_cast",
+  "const_cast",
+  "reinterpret_cast",
+  "new ",
+  "delete ",
+  "public:",
+  "protected:",
+  "private:",
+  // other cpp-only keywords:
+  //explicit/mutable/final
+  //try/catch/throw
+  //operator
+  //"cout <<" / "cin >>"
+  //true/false
+];
 
 /**
  * Checks for cpp code in #c-help-text and suggests #cpp-help-text instead
  */
 export default class CHelpRedirect extends BotComponent {
-    constructor(wheatley: Wheatley) {
-        super(wheatley);
+  constructor(wheatley: Wheatley) {
+    super(wheatley);
 
-        this.add_command(
-            new TextBasedCommandBuilder("not-c")
-                .set_description("Mark C++ code in the C help channel")
-                .add_user_option({
-                    title: "user",
-                    description: "User who posted the code",
-                    required: false,
-                })
-                .set_handler(this.not_c.bind(this)),
-        );
+    this.add_command(
+      new TextBasedCommandBuilder("not-c")
+        .set_description("Mark C++ code in the C help channel")
+        .add_user_option({
+          title: "user",
+          description: "User who posted the code",
+          required: false,
+        })
+        .set_handler(this.not_c.bind(this)),
+    );
+  }
+
+  check_message(message: Discord.Message): boolean {
+    if (!message.content.includes(code_block_start)) {
+      // to avoid false positives, only check inside code blocks
+      return false;
     }
 
-    check_message(message: Discord.Message) : boolean {
-        if (!message.content.includes(code_block_start)) {
-            // to avoid false positives, only check inside code blocks
-            return false;
+    let text = message.content;
+
+    while (text.search(code_block_start) > -1) {
+      let start = text.search(code_block_start);
+      let end = text
+        .substring(start + code_block_start.length)
+        .search(code_block_start);
+      let block = text.substring(
+        start + code_block_start.length,
+        start + code_block_start.length + end,
+      );
+
+      for (const keyword of cpp_keywords) {
+        if (block.includes(keyword)) {
+          return true;
         }
+      }
 
-        let text = message.content;
+      text = text.substring(
+        start + code_block_start.length + end + code_block_start.length,
+      );
+    }
+    return false;
+  }
 
-        while(text.search(code_block_start) > -1)
-        {
-            let start = text.search(code_block_start)
-            let end = text.substring(start + code_block_start.length).search(code_block_start)
-            let block = text.substring(start + code_block_start.length, start + code_block_start.length + end)
+  async not_c(command: TextBasedCommand, user: Discord.User | null) {
+    assert(command.channel);
+    assert(command.channel instanceof Discord.GuildChannel);
+    //for manual triggers, trust the caller and don't check the message
+    //supposedly the automatic check didn't trigger, so checking the message again would fail again
+    if (user) {
+      await command.channel.send(
+        `<@${user.id}> Your code looks like C++ code, but this is a C channel. Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>? `,
+      );
+    } else {
+      await command.channel.send(
+        `This code looks like C++ code, but this is a C channel. Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
+      );
+    }
+  }
 
-            for(const keyword of cpp_keywords)
-            {
-                if(block.includes(keyword))
-                {
-                    return true;
-                }
-            }
-
-            text = text.substring(start + code_block_start.length + end + code_block_start.length)
-        }
-        return false;
+  override async on_message_create(message: Discord.Message) {
+    // Ignore self, bots, and messages outside TCCPP (e.g. dm's)
+    if (
+      message.author.id == this.wheatley.client.user!.id ||
+      message.author.bot ||
+      message.guildId != this.wheatley.TCCPP.id
+    ) {
+      return;
     }
 
-    async not_c(command: TextBasedCommand, user: Discord.User | null) {
-        assert(command.channel);
-        assert(command.channel instanceof Discord.GuildChannel);
-        //for manual triggers, trust the caller and don't check the message
-        //supposedly the automatic check didn't trigger, so checking the message again would fail again
-        if(user)
-        {
-            await command.channel.send(`<@${user.id}> Your code looks like C++ code, but this is a C channel. Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>? `);
-        }
-        else
-        {
-            await command.channel.send(`This code looks like C++ code, but this is a C channel. Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`);
-        }
+    // Only check messages in #c-help-text
+    if (message.channel.id != this.wheatley.channels.c_help_text.id) {
+      return;
     }
 
-    override async on_message_create(message: Discord.Message) {
-        // Ignore self, bots, and messages outside TCCPP (e.g. dm's)
-        if (
-            message.author.id == this.wheatley.client.user!.id ||
-            message.author.bot ||
-            message.guildId != this.wheatley.TCCPP.id
-        ) {
-            return;
-        }
-
-        // Only check messages in #c-help-text
-        if (message.channel.id != this.wheatley.channels.c_help_text.id)
-        {
-            return;
-        }
-
-        if(this.check_message(message))
-        {
-            await message.reply(`<@${message.author.id}> Your code looks like C++ code, but this is a C channel. Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`);
-        }
+    if (this.check_message(message)) {
+      await message.reply(
+        `<@${message.author.id}> Your code looks like C++ code, but this is a C channel. Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
+      );
     }
+  }
 }

--- a/src/components/c-help-redirect.ts
+++ b/src/components/c-help-redirect.ts
@@ -95,6 +95,13 @@ export default class CHelpRedirect extends BotComponent {
     async not_c(command: TextBasedCommand, user: Discord.User | null) {
         assert(command.channel);
         assert(command.channel instanceof Discord.GuildChannel);
+
+        // Only allowed in #c-help-text
+        if (command.channel.id != this.wheatley.channels.c_help_text.id) {
+            await command.reply(`Can only be used in <#${this.wheatley.channels.c_help_text.id}>`, true);
+            return;
+        }
+
         //for manual triggers, trust the caller and don't check the message
         //supposedly the automatic check didn't trigger, so checking the message again would fail again
         if (user) {

--- a/src/components/c-help-redirect.ts
+++ b/src/components/c-help-redirect.ts
@@ -5,6 +5,7 @@ import { Wheatley } from "../wheatley.js";
 import { TextBasedCommandBuilder } from "../command-abstractions/text-based-command-builder.js";
 import { TextBasedCommand } from "../command-abstractions/text-based-command.js";
 import { DAY } from "../common.js";
+import { M } from "../utils/debugging-and-logging.js";
 
 const code_block_start = "```";
 

--- a/src/components/c-help-redirect.ts
+++ b/src/components/c-help-redirect.ts
@@ -1,4 +1,5 @@
 import * as Discord from "discord.js";
+import { strict as assert } from "assert";
 import { BotComponent } from "../bot-component.js";
 import { Wheatley } from "../wheatley.js";
 import { TextBasedCommandBuilder } from "../command-abstractions/text-based-command-builder.js";
@@ -38,8 +39,8 @@ export default class CHelpRedirect extends BotComponent {
         super(wheatley);
 
         this.add_command(
-            new TextBasedCommandBuilder(["not-c"])
-                .set_description(["Mark C++ code in the C help channel"])
+            new TextBasedCommandBuilder("not-c")
+                .set_description("Mark C++ code in the C help channel")
                 .add_user_option({
                     title: "user",
                     description: "User who posted the code",
@@ -77,6 +78,8 @@ export default class CHelpRedirect extends BotComponent {
     }
 
     async not_c(command: TextBasedCommand, user: Discord.User | null) {
+        assert(command.channel);
+        assert(command.channel instanceof Discord.GuildChannel);
         //for manual triggers, trust the caller and don't check the message
         //supposedly the automatic check didn't trigger, so checking the message again would fail again
         if(user)
@@ -100,7 +103,7 @@ export default class CHelpRedirect extends BotComponent {
         }
 
         // Only check messages in #c-help-text
-        if (message.channel.id != this.wheatley.channels.c_help_text)
+        if (message.channel.id != this.wheatley.channels.c_help_text.id)
         {
             return;
         }

--- a/src/components/c-help-redirect.ts
+++ b/src/components/c-help-redirect.ts
@@ -11,7 +11,7 @@ import { SelfClearingSet } from "../utils/containers.js";
 const code_block_start = "```";
 
 const cpp_keywords = [
-    "std::", //just :: would work too, this is slightly less prone to false positives
+    "std::", // just :: would work too, this is slightly less prone to false positives
     "using namespace ",
     "class ",
     "typename ",
@@ -21,8 +21,8 @@ const cpp_keywords = [
     "static_cast",
     "const_cast",
     "reinterpret_cast",
-    "= new ", //too common to include just "new"
-    //"delete ", //too common
+    "= new ", // too common to include just "new"
+    // "delete ", // too common
     "delete[]",
     "public:",
     "protected:",
@@ -36,7 +36,7 @@ const not_c_keywords = [
     "try",
     "catch",
     "throw",
-    "operator", //possibly list all operator+ etc. to be on the safe side
+    "operator", // possibly list all operator+ etc. to be on the safe side
     "cout<<",
     "cout <<",
     "cin>>",
@@ -54,16 +54,15 @@ const maybe_c_keywords = [
     "malloc",
     "calloc",
     "realloc",
-    "free(", //too common to include just "free"
+    "free(", // too common to include just "free"
 ];
 
 /**
  * Checks for cpp code in #c-help-text and suggests #cpp-help-text instead, and vice versa
  */
 export default class CHelpRedirect extends BotComponent {
-    
-    //for timeouts on triggering on the same user
-    //use the same set for both channels, shouldn't be an issue in practice
+    // For timeouts on triggering on the same user
+    // use the same set for both channels, shouldn't be an issue in practice
     readonly auto_triggered_users = new SelfClearingSet<string>(1 * HOUR);
 
     constructor(wheatley: Wheatley) {
@@ -110,7 +109,7 @@ export default class CHelpRedirect extends BotComponent {
 
     check_message_for_cpp_code(message: Discord.Message): boolean {
         if (!message.content.includes(code_block_start)) {
-            // to avoid false positives, only check inside code blocks
+            // To avoid false positives, only check inside code blocks
             return false;
         }
 
@@ -134,7 +133,7 @@ export default class CHelpRedirect extends BotComponent {
 
     check_message_for_c_code(message: Discord.Message): boolean {
         if (!message.content.includes(code_block_start)) {
-            // to avoid false positives, only check inside code blocks
+            // To avoid false positives, only check inside code blocks
             return false;
         }
 
@@ -145,9 +144,9 @@ export default class CHelpRedirect extends BotComponent {
             const end = text.substring(start + code_block_start.length).search(code_block_start);
             const block = text.substring(start + code_block_start.length, start + code_block_start.length + end);
 
-            //for C code, the block must not have any C++ keywords
-            //including inconclusive keywords
-            //and have some C keyword
+            // For C code, the block must not have any C++ keywords
+            // including inconclusive keywords
+            // and have some C keyword
 
             let c_code_found = false;
             let cpp_code_found = false;
@@ -189,8 +188,8 @@ export default class CHelpRedirect extends BotComponent {
             return;
         }
 
-        //for manual triggers, trust the caller and don't check the message
-        //supposedly the automatic check didn't trigger, so checking the message again would fail again
+        // For manual triggers, trust the caller and don't check the message
+        // Supposedly the automatic check didn't trigger, so checking the message again would fail again
         if (user) {
             await command.channel.send(
                 `<@${user.id}> Your code looks like C++ code, but this is a C channel. ` +
@@ -214,8 +213,8 @@ export default class CHelpRedirect extends BotComponent {
             return;
         }
 
-        //for manual triggers, trust the caller and don't check the message
-        //supposedly the automatic check didn't trigger, so checking the message again would fail again
+        // For manual triggers, trust the caller and don't check the message
+        // Supposedly the automatic check didn't trigger, so checking the message again would fail again
         if (user) {
             await command.channel.send(
                 `<@${user.id}> Your code looks like C code, but this is a C++ channel. ` +
@@ -239,14 +238,13 @@ export default class CHelpRedirect extends BotComponent {
             return;
         }
 
-        //only auto-check new members
+        // Only auto-check new members
         if (await this.is_not_new_member(message)) {
             return;
         }
 
-        //timeout for triggering on the same user
-        if(this.auto_triggered_users.has(message.author.id))
-        {
+        // Timeout for triggering on the same user
+        if (this.auto_triggered_users.has(message.author.id)) {
             return;
         }
 

--- a/src/components/c-help-redirect.ts
+++ b/src/components/c-help-redirect.ts
@@ -1,6 +1,8 @@
 import * as Discord from "discord.js";
 import { BotComponent } from "../bot-component.js";
 import { Wheatley } from "../wheatley.js";
+import { TextBasedCommandBuilder } from "../command-abstractions/text-based-command-builder.js";
+import { TextBasedCommand } from "../command-abstractions/text-based-command.js";
 
 const code_block_start = "```";
 
@@ -61,7 +63,7 @@ export default class CHelpRedirect extends BotComponent {
             let end = text.substring(start + code_block_start.length).search(code_block_start)
             let block = text.substring(start + code_block_start.length, start + code_block_start.length + end)
 
-            for(var keyword of cpp_keywords)
+            for(const keyword of cpp_keywords)
             {
                 if(block.includes(keyword))
                 {

--- a/src/components/c-help-redirect.ts
+++ b/src/components/c-help-redirect.ts
@@ -4,6 +4,7 @@ import { BotComponent } from "../bot-component.js";
 import { Wheatley } from "../wheatley.js";
 import { TextBasedCommandBuilder } from "../command-abstractions/text-based-command-builder.js";
 import { TextBasedCommand } from "../command-abstractions/text-based-command.js";
+import { DAY } from "../common.js";
 
 const code_block_start = "```";
 
@@ -48,6 +49,22 @@ export default class CHelpRedirect extends BotComponent {
                 })
                 .set_handler(this.not_c.bind(this)),
         );
+    }
+
+    async is_new_member(message: Discord.Message) {
+        let member: Discord.GuildMember;
+        if (message.member == null) {
+            try {
+                member = await message.guild!.members.fetch(message.author.id);
+            } catch (error) {
+                M.warn("Failed to get user", message.author.id);
+                return false;
+            }
+        } else {
+            member = message.member;
+        }
+        assert(member.joinedTimestamp != null);
+        return Date.now() - member.joinedTimestamp <= 7 * DAY;
     }
 
     check_message(message: Discord.Message): boolean {
@@ -104,6 +121,12 @@ export default class CHelpRedirect extends BotComponent {
 
         // Only check messages in #c-help-text
         if (message.channel.id != this.wheatley.channels.c_help_text.id) {
+            return;
+        }
+
+        //only bother new members
+        if(await this.is_new_member(message))
+        {
             return;
         }
 


### PR DESCRIPTION
Closes #26 

Automatically checks code blocks posted in #c-help-text, and if it detects C++ code, informs the user.
Also has a manual /not-c command, for cases when the automated check doesn't catch something.

Note: the message will still trigger if someone tries to cheat the system, like calling a variable "template" or something.