### PR TITLE
Fix broken grammar in wiki article

### DIFF
--- a/wiki_articles/overload_less.md
+++ b/wiki_articles/overload_less.md
@@ -1,7 +1,7 @@
 # Overloading the Less Than Operator
 
-The less than operator returns `true` iff one object less than the other. If it establishes a [strict weak ordering][1]
-and makes the type *[LessThanComparable][2]*, which allows using the type in a `std::map`, in `std::sort` and other
+The less than operator returns `true` iff one object less than the other. If it establishes a [strict weak ordering][1],
+it makes the type *[LessThanComparable][2]*, which allows using the type in a `std::map`, in `std::sort` and other
 algorithms.
 
 [1]: https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings


### PR DESCRIPTION
Commit https://github.com/TCCPP/wheatley/commit/7f29c9f6c305eac0ece2b0a2684ff8ba2031155b which applied suggested changes in https://github.com/TCCPP/wheatley/issues/63 accidentally broke the grammar in one sentence.

Note that even if the "if" was removed and the new sentence was grammatically correct, it would be semantically incorrect because overloading `<` in itself does not satisfy *LessThanComparable*; a strict weak ordering is required, as the old wording states.