### PR TITLE
Add template_argument_deduction and template_instantiation articles

### DIFF
--- a/wiki_articles/template_argument_deduction.md
+++ b/wiki_articles/template_argument_deduction.md
@@ -1,0 +1,68 @@
+# What Is Template Argument Deduction?
+
+Sometimes, it is possible to omit template arguments when using a template,
+letting the compiler infer them instead.
+
+## Template function
+?inline
+```cpp
+template<typename T>
+void print(T arg) {
+    std::cout << arg << ' ';
+}
+```
+
+## Usage
+?inline
+```cpp
+print(42);
+print("Hello");
+print<std::string>("Hi");
+```
+
+In the first two calls to `print`, no template argument is provided. Since `print`
+takes a parameter of type `T`, the compiler can match `T` to the type of
+the provided arguments: `int` for `42`, and `const char*` for `"Hello"`.
+
+The third call inhibits deduction by imposing `T`. An `std::string` is constructed
+from `"Hi"`, and a copy of it is passed to the function.
+
+The compiler cannot always deduce template parameters, notably when a template
+parameter appears only in the return type of a function:
+
+## Template function
+?inline
+```cpp
+template<class T>
+T make(int arg) {
+  return T(arg);
+}
+```
+
+## Usage
+?inline
+```cpp
+Foo foo = make<Foo>(42);
+// ok, returns Foo
+Foo bar = make(45);
+// error: cannot deduce T
+```
+
+Template parameters can be partially deduced independently of each other:
+
+## Template function
+?inline
+```cpp
+template<class T, class A>
+T make(A arg) {
+    return T(arg);
+}
+```
+
+## Usage
+?inline
+```cpp
+Foo foo = make<Foo>(42);
+// T = Foo (explicit)
+// A = int (deduced)
+```

--- a/wiki_articles/template_instantiation.md
+++ b/wiki_articles/template_instantiation.md
@@ -1,0 +1,36 @@
+# What Is Template Instantiation?
+
+Templates are not real entities until a piece code uses them with arguments.
+When this happens, the compiler replaces the template parameters with the
+provided arguments, deriving the generic code into specific code.
+
+The generic code needs to be available in any translation unit that uses it. This
+is why templates are typically declared **and** defined entirely in headers.
+
+## Template function
+?inline
+```cpp
+template<typename T>
+void print(T arg) {
+    std::cout << arg << ' ';
+}
+```
+
+## Usage
+?inline
+```cpp
+print(42);
+print("Hello");
+```
+
+On the first call to `print`, the compiler substitutes `T` for `int` in the
+template code, _instantiating_ it into a new function. The second call to `print`
+causes `T` to be substituted for `const char*`, instantiating the template again.
+
+Here, `T` is said to be _deduced_: the compiler infers `T` from the type of the
+argument to `print`.
+
+**Output:**
+```
+42 Hello 
+```


### PR DESCRIPTION
Add template_argument_deduction and template_instantiation articles

Kinda big, but on the okay side of it IMHO.
See what they look like in [this Discord message](https://discord.com/channels/331718482485837825/506274405500977153/1220326543193014345) and [this one](https://discord.com/channels/331718482485837825/506274405500977153/1220334961530503258).

Since Wheatley doesn't seem to be rendering inline tags correctly, I went ahead and did this little bit of a montage to give a better idea of how they will (hopefully) end up looking:
![image](https://github.com/TCCPP/wheatley/assets/37235115/ca2582a7-d33e-4304-895b-1511dc2444db)
![image](https://github.com/TCCPP/wheatley/assets/37235115/f2bcec08-17e5-4bea-8dbd-03d420623d18)
