### PR TITLE
Disable auto-reply if a link is detected in the output

### DIFF
--- a/src/components/anti-everyone.ts
+++ b/src/components/anti-everyone.ts
@@ -1,7 +1,7 @@
 import * as Discord from "discord.js";
 import { BotComponent } from "../bot-component.js";
 import { Wheatley } from "../wheatley.js";
-import { colors } from "../common.js";
+import { colors, MINUTE, HOUR } from "../common.js";
 import { M } from "../utils/debugging-and-logging.js";
 import { SelfClearingMap } from "../utils/containers.js";
 
@@ -22,10 +22,7 @@ export default class AntiEveryone extends BotComponent {
      *
      * @note This is limited to 50 replies, in order to keep memory usage down.
      */
-    public replies: SelfClearingMap<Discord.User, AntiEveryoneMessageCache[]> = new SelfClearingMap(
-        1000 * 60 * 60,
-        1000 * 60,
-    );
+    public replies: SelfClearingMap<Discord.User, AntiEveryoneMessageCache[]> = new SelfClearingMap(HOUR, MINUTE);
     constructor(wheatley: Wheatley) {
         super(wheatley);
     }

--- a/src/components/anti-everyone.ts
+++ b/src/components/anti-everyone.ts
@@ -7,6 +7,10 @@ import { SelfClearingMap } from "../utils/containers.js";
 
 const failed_everyone_re = /(?:@everyone|@here)/g; // todo: word boundaries?
 
+export interface AntiEveryoneMessageCache extends Discord.Message {
+    replyTo: Discord.Message["id"];
+}
+
 /**
  * Responds to users attempting to ping @everyone or @here
  * with a message discouraging the behavior.
@@ -14,10 +18,13 @@ const failed_everyone_re = /(?:@everyone|@here)/g; // todo: word boundaries?
 export default class AntiEveryone extends BotComponent {
     /**
      * Replies that have been made to users who attempted to ping everyone.
-     * 
+     *
      * @note This is limited to 50 replies, in order to keep memory usage down.
      */
-    public replies: SelfClearingMap<Discord.User, Discord.Message[]> = new SelfClearingMap<Discord.User, Discord.Message[]>(1000 * 60 * 60, 1000 * 60);
+    public replies: SelfClearingMap<Discord.User, AntiEveryoneMessageCache[]> = new SelfClearingMap(
+        1000 * 60 * 60,
+        1000 * 60,
+    );
     constructor(wheatley: Wheatley) {
         super(wheatley);
     }
@@ -38,13 +45,24 @@ export default class AntiEveryone extends BotComponent {
         if (message.content.match(failed_everyone_re) != null) {
             // NOTE: .toLocaleString("en-US") formats this number with commas.
             const memberCount = this.wheatley.TCCPP.members.cache.size.toLocaleString("en-US");
-            await message.reply({
+
+            // Store the reply for later deletion, if necessary
+            if (!this.replies.has(message.author)) {
+                this.replies.set(message.author, []);
+            }
+            const reply = await message.reply({
                 content: `Did you really just try to ping ${memberCount} people?`,
             });
 
-            // Store the reply for later deletion, if necessary
-            if(!this.replies.has(message.author)) this.replies.set(message.author, []);
-            this.replies.get(message.author)!.push(message);
+            // Store the reply for later deletion, along with the message it was replying to
+            this.replies.get(message.author)!.push(
+                Object.assign(
+                    {
+                        replyTo: message.id,
+                    },
+                    reply,
+                ),
+            );
         }
     }
 
@@ -54,7 +72,9 @@ export default class AntiEveryone extends BotComponent {
      * @TODO: Actually bind this into the anti-spam system
      */
     async deleteReplies(user: Discord.User) {
-        if(!this.replies.has(user)) return;
+        if (!this.replies.has(user)) {
+            return;
+        }
 
         const deletedAll = Promise.all(this.replies.get(user)!.map(reply => reply.delete()));
         this.replies.remove(user);
@@ -66,13 +86,16 @@ export default class AntiEveryone extends BotComponent {
      * @param message The message that was deleted
      */
     override async on_message_delete(message: Discord.Message<boolean>): Promise<void> {
-        if(Math.abs(Date.now() - message.createdTimestamp) > 1000) return; // Message was likely deleted by the user
+        if (Math.abs(Date.now() - message.createdTimestamp) > 1000) {
+            // Message was likely deleted by the user, rather than automatically
+            return;
+        }
 
         const author = message.author;
         const replies = this.replies.get(author);
-        const reply = replies?.find(reply => reply.reference?.messageId == message.id);
-        if(reply) {
-            reply.deleteReply();
+        const reply = replies?.find(reply => reply.replyTo == message.id);
+        if (reply) {
+            await reply.delete();
             this.replies.set(author, replies?.filter(reply => reply.id !== message.id) ?? []);
         }
     }

--- a/src/components/anti-everyone.ts
+++ b/src/components/anti-everyone.ts
@@ -67,7 +67,15 @@ export default class AntiEveryone extends BotComponent {
             return;
         }
 
-        const deletedAll = Promise.all(this.replies.get(user)!.map(replyCache => replyCache.reply.delete()));
+        const deletedAll = Promise.all(
+            this.replies.get(user)!.map(async reply_cache => {
+                try {
+                    await reply_cache.reply.delete();
+                } catch (e) {
+                    // If the message was already deleted, we don't need to do anything
+                }
+            }),
+        );
         this.replies.remove(user);
         return deletedAll;
     }
@@ -86,7 +94,11 @@ export default class AntiEveryone extends BotComponent {
         const replies = this.replies.get(author);
         const reply_cache = replies?.find(reply => reply.reply_to == message.id);
         if (reply_cache) {
-            await reply_cache.reply.delete();
+            try {
+                await reply_cache.reply.delete();
+            } catch (e) {
+                // If the message was already deleted, we don't need to do anything
+            }
             this.replies.set(author, replies?.filter(reply => reply.reply_to !== message.id) ?? []);
         }
     }

--- a/src/components/anti-everyone.ts
+++ b/src/components/anti-everyone.ts
@@ -5,6 +5,7 @@ import { colors } from "../common.js";
 import { M } from "../utils/debugging-and-logging.js";
 
 const failed_everyone_re = /(?:@everyone|@here)/g; // todo: word boundaries?
+const link_re = /(\s|^)https?:\/\/[\w\d]/g; // todo: be a bit more specific
 
 /**
  * Responds to users attempting to ping @everyone or @here
@@ -28,7 +29,7 @@ export default class AntiEveryone extends BotComponent {
         ) {
             return;
         }
-        if (message.content.match(failed_everyone_re) != null) {
+        if (message.content.match(failed_everyone_re) != null && link_re.test(message.content)) {
             // NOTE: .toLocaleString("en-US") formats this number with commas.
             const memberCount = this.wheatley.TCCPP.members.cache.size.toLocaleString("en-US");
             await message.reply({

--- a/src/components/anti-everyone.ts
+++ b/src/components/anti-everyone.ts
@@ -17,7 +17,7 @@ export default class AntiEveryone extends BotComponent {
      * 
      * @note This is limited to 50 replies, in order to keep memory usage down.
      */
-    public replies: SelfClearingMap<Discord.User, Discord.Message[]> = new SelfClearingMap(1000 * 60 * 60 * 24, 1000 * 60 * 60 * 24);
+    public replies: SelfClearingMap<Discord.User, Discord.Message[]> = new SelfClearingMap<Discord.User, Discord.Message[]>(1000 * 60 * 60, 1000 * 60);
     constructor(wheatley: Wheatley) {
         super(wheatley);
     }

--- a/src/components/anti-everyone.ts
+++ b/src/components/anti-everyone.ts
@@ -8,7 +8,7 @@ import { SelfClearingMap } from "../utils/containers.js";
 const failed_everyone_re = /(?:@everyone|@here)/g; // todo: word boundaries?
 
 export interface AntiEveryoneMessageCache {
-    replyTo: Discord.Message["id"];
+    reply_to: Discord.Message["id"];
     reply: Discord.Message;
 }
 
@@ -53,7 +53,7 @@ export default class AntiEveryone extends BotComponent {
             });
 
             // Store the reply for later deletion, along with the message it was replying to
-            this.replies.get(message.author)!.push({ replyTo: message.id, reply });
+            this.replies.get(message.author)!.push({ reply_to: message.id, reply });
         }
     }
 
@@ -62,7 +62,7 @@ export default class AntiEveryone extends BotComponent {
      * @note this should be used to auto-hide spam message replies in order to try and reduce the effect of spam
      * @TODO: Actually bind this into the anti-spam system
      */
-    async deleteReplies(user: Discord.User) {
+    async delete_replies(user: Discord.User) {
         if (!this.replies.has(user)) {
             return;
         }
@@ -84,10 +84,10 @@ export default class AntiEveryone extends BotComponent {
 
         const author = message.author;
         const replies = this.replies.get(author);
-        const replyCache = replies?.find(reply => reply.replyTo == message.id);
-        if (replyCache) {
-            await replyCache.reply.delete();
-            this.replies.set(author, replies?.filter(reply => reply.replyTo !== message.id) ?? []);
+        const reply_cache = replies?.find(reply => reply.reply_to == message.id);
+        if (reply_cache) {
+            await reply_cache.reply.delete();
+            this.replies.set(author, replies?.filter(reply => reply.reply_to !== message.id) ?? []);
         }
     }
 }

--- a/src/components/anti-everyone.ts
+++ b/src/components/anti-everyone.ts
@@ -78,9 +78,6 @@ export default class AntiEveryone extends BotComponent {
         }
         // Remove the user from the cache, mainly to reduce clutter
         this.replies.remove(user);
-
-        // Wait for all the replies to be deleted
-        return;
     }
 
     /**

--- a/src/components/anti-everyone.ts
+++ b/src/components/anti-everyone.ts
@@ -5,7 +5,7 @@ import { colors } from "../common.js";
 import { M } from "../utils/debugging-and-logging.js";
 
 const failed_everyone_re = /(?:@everyone|@here)/g; // todo: word boundaries?
-const link_re = /(\s|^)https?:\/\/[\w\d]/g; // todo: be a bit more specific
+const link_re = /(\s|^)https?:\/\/\S/g;
 
 /**
  * Responds to users attempting to ping @everyone or @here

--- a/src/components/anti-everyone.ts
+++ b/src/components/anti-everyone.ts
@@ -20,7 +20,7 @@ export default class AntiEveryone extends BotComponent {
     /**
      * Replies that have been made to users who attempted to ping everyone.
      *
-     * @note This is limited to 50 replies, in order to keep memory usage down.
+     * @note This is limited to the last hour, in order to keep memory usage down.
      */
     public replies: SelfClearingMap<Discord.User, AntiEveryoneMessageCache[]> = new SelfClearingMap(HOUR, MINUTE);
     constructor(wheatley: Wheatley) {


### PR DESCRIPTION
This disables the reply message if a link-like string is detected inside of `@everyone`/`@here` messages, mainly to not allow advertisements to stay up within Weatley's reply.