### PR TITLE
Add users current score to the scoreboard

### DIFF
--- a/src/components/the-button.ts
+++ b/src/components/the-button.ts
@@ -270,10 +270,10 @@ export default class TheButton extends BotComponent {
                 const tag = entry.tag == "" ? `<@${entry.user}>` : entry.tag;
                 description += `${tag}: ${round(entry.score, 1)}\n`;
             }
-            // Users current score
-            const user = scores.find(entry => entry.user == interaction.user.id);
-            if (user) {
-                description += `\nYour score: ${round(user.score, 1)}`;
+            // If user exists in the scoreboard, show their score.
+            const currentUser = await this.wheatley.database.button_scoreboard.findOne({ user: interaction.user.id });
+            if (currentUser != null) {
+                description += `\n\nYour Current score: ${round(currentUser.score, 1)}`;
             }
             embed.setDescription(description);
             await interaction.reply({

--- a/src/components/the-button.ts
+++ b/src/components/the-button.ts
@@ -270,6 +270,11 @@ export default class TheButton extends BotComponent {
                 const tag = entry.tag == "" ? `<@${entry.user}>` : entry.tag;
                 description += `${tag}: ${round(entry.score, 1)}\n`;
             }
+            // Users current score
+            const user = scores.find(entry => entry.user == interaction.user.id);
+            if (user) {
+                description += `\nYour score: ${round(user.score, 1)}`;
+            }
             embed.setDescription(description);
             await interaction.reply({
                 embeds: [embed],


### PR DESCRIPTION
Currently there is no manner with The Button to be able to tell what your current score is without pressing the button. This minor addition adds your current score to the scoreboard button when pressed.

I've kept this change pretty minor, but another possibility is to also display your current ranking. I've though for the time being kept the change small.