### PR TITLE
Optimize self cleaning containers

### DIFF
--- a/src/utils/__tests__/containers.ts
+++ b/src/utils/__tests__/containers.ts
@@ -1,5 +1,6 @@
 import { describe, expect, beforeEach, afterEach, vi, it } from "vitest";
-import { SelfClearingMap, SelfClearingSet } from "../containers.js";
+import { SelfClearingMap, SelfClearingSet, force_clear_containers } from "../containers.js";
+import * as p_timers from "node:timers/promises";
 
 import { setFlagsFromString } from "v8";
 import { runInNewContext } from "vm";
@@ -14,20 +15,19 @@ if (!(gc as unknown as boolean)) {
 }
 
 async function moveForwardBy(time: number) {
-    vi.setSystemTime((vi.getMockedSystemTime()?.getTime() || 0) + time);
-    return vi.advanceTimersByTimeAsync(time);
+    return await vi.advanceTimersByTimeAsync(time);
 }
 
 describe.sequential("SelfClearingMap", () => {
     beforeEach(() => {
         // tell vitest we use mocked timers
-        vi.useFakeTimers({ toFake: ["nextTick", "setTimeout", "setImmediate", "Date"] });
+        vi.useFakeTimers({ toFake: ["nextTick", "setTimeout", "setImmediate", "Date", "setInterval"] });
         vi.setSystemTime(0);
     });
-    afterEach(() => {
-        gc();
-        vi.runOnlyPendingTimers();
-        gc();
+    afterEach(async () => {
+        await force_clear_containers();
+        await p_timers.setImmediate();
+        await force_clear_containers();
     });
 
     it.sequential("should remove expired entries", async () => {
@@ -58,17 +58,88 @@ describe.sequential("SelfClearingMap", () => {
         await vi.advanceTimersToNextTimerAsync();
         map.set("a", 0);
         expect(map.has("a")).to.equal(true);
-        console.log(map);
 
         await moveForwardBy(1000);
-        console.log(vi.getMockedSystemTime()?.getTime());
 
         expect(map.has("a")).to.equal(true);
     });
 
-    /**
-     * TODO: Add more tests, specifically for the timer logic and multiple maps
-     */
+    it.sequential("Should call the on_remove callback", async () => {
+        const map = new SelfClearingMap<string, number>(1000);
+        const on_remove = vi.fn();
+        map.on_remove = on_remove;
+
+        await vi.advanceTimersToNextTimerAsync();
+        map.set("a", 0);
+
+        expect(map.has("a")).to.equal(true);
+        expect(on_remove).not.toHaveBeenCalled();
+
+        await moveForwardBy(1002);
+
+        expect(on_remove).toHaveBeenCalled();
+    });
+
+    it.sequential("Should run the sweep only when needed", async () => {
+        const map = new SelfClearingMap<string, number>(1000);
+        const map2 = new SelfClearingMap<string, number>(3000);
+        const spy = vi.spyOn(map, "sweep");
+        const spy2 = vi.spyOn(map2, "sweep");
+        await vi.advanceTimersToNextTimerAsync();
+
+        spy.mockClear();
+        spy2.mockClear();
+        map.set("a", 0);
+        map2.set("a", 0);
+
+        expect(spy).not.toHaveBeenCalled();
+        expect(spy2).not.toHaveBeenCalled();
+
+        await moveForwardBy(1000);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy2).not.toHaveBeenCalled();
+
+        await moveForwardBy(2000);
+        expect(spy).toBeCalledTimes(3);
+        expect(spy2).toHaveBeenCalledTimes(1);
+    });
+
+    it.sequential("Should compute the correct time to the next sweep", async () => {
+        const map = new SelfClearingMap<string, number>(1000);
+
+        vi.setSystemTime(500);
+        expect(map.next_interval()).to.equal(500);
+
+        vi.setSystemTime(995);
+        expect(map.next_interval()).to.equal(1005);
+
+        vi.setSystemTime(1000);
+        expect(map.next_interval()).to.equal(1000);
+    });
+
+    it.sequential("Should decide whether to run the sweep correctly", async () => {
+        const map = new SelfClearingMap<string, number>(1000);
+        await vi.advanceTimersToNextTimerAsync();
+
+        vi.setSystemTime(500);
+        expect(map.should_run()).to.equal(false);
+
+        vi.setSystemTime(1000);
+        expect(map.should_run()).to.equal(true);
+
+        vi.setSystemTime(1001);
+        expect(map.should_run()).to.equal(true);
+
+        vi.setSystemTime(995);
+        expect(map.should_run()).to.equal(false);
+
+        vi.setSystemTime(1995);
+        expect(map.should_run()).to.equal(true);
+        map.sweep();
+
+        vi.setSystemTime(2000);
+        expect(map.should_run()).to.equal(false);
+    });
 });
 
 describe.sequential("SelfClearingSet", () => {
@@ -103,7 +174,6 @@ describe.sequential("SelfClearingSet", () => {
         expect(set.has("a")).to.equal(true);
 
         await moveForwardBy(500);
-        console.log(vi.getMockedSystemTime()?.getTime());
 
         expect(set.has("a")).to.equal(true);
     });
@@ -120,11 +190,103 @@ describe.sequential("SelfClearingSet", () => {
         expect(set.has("a")).to.equal(true);
     });
 
-    /**
-     * TODO: Add more tests, specifically for the timer logic and multiple sets
-     */
+    it.sequential.only("Should call the on_remove callback", async () => {
+        const on_remove = vi.fn();
+        const set = new SelfClearingSet<string>(1000, 1000, on_remove);
+
+        await vi.advanceTimersToNextTimerAsync();
+        set.insert("a");
+
+        expect(set.has("a")).to.equal(true);
+        expect(on_remove).not.toHaveBeenCalled();
+
+        await moveForwardBy(1002);
+
+        expect(set.has("a")).to.equal(false);
+        expect(on_remove).toHaveBeenCalled();
+    });
+
+    it.sequential("Should run the sweep only when needed", async () => {
+        const set = new SelfClearingSet<string>(1000);
+        const set2 = new SelfClearingSet<string>(3000);
+        const spy = vi.spyOn(set, "sweep");
+        const spy2 = vi.spyOn(set2, "sweep");
+        await vi.advanceTimersToNextTimerAsync();
+
+        spy.mockClear();
+        spy2.mockClear();
+        set.insert("a");
+        set2.insert("a");
+
+        expect(spy).not.toHaveBeenCalled();
+        expect(spy2).not.toHaveBeenCalled();
+
+        await moveForwardBy(1000);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy2).not.toHaveBeenCalled();
+
+        await moveForwardBy(2000);
+        expect(spy).toBeCalledTimes(3);
+        expect(spy2).toHaveBeenCalledTimes(1);
+    });
+
+    it.sequential("Should compute the correct time to the next sweep", async () => {
+        const set = new SelfClearingSet<string>(1000);
+
+        vi.setSystemTime(500);
+        expect(set.next_interval()).to.equal(500);
+
+        vi.setSystemTime(995);
+        expect(set.next_interval()).to.equal(1005);
+
+        vi.setSystemTime(1000);
+        expect(set.next_interval()).to.equal(1000);
+    });
+
+    it.sequential("Should decide whether to run the sweep correctly", async () => {
+        const set = new SelfClearingSet<string>(1000);
+        await vi.advanceTimersToNextTimerAsync();
+
+        vi.setSystemTime(500);
+        expect(set.should_run()).to.equal(false);
+
+        vi.setSystemTime(1000);
+        expect(set.should_run()).to.equal(true);
+
+        vi.setSystemTime(1001);
+        expect(set.should_run()).to.equal(true);
+
+        vi.setSystemTime(995);
+        expect(set.should_run()).to.equal(false);
+
+        vi.setSystemTime(1995);
+        expect(set.should_run()).to.equal(true);
+        set.sweep();
+
+        vi.setSystemTime(2000);
+        expect(set.should_run()).to.equal(false);
+    });
 });
 
 /**
  * TODO: Add more tests, specifically for sets and maps together
  */
+
+describe.sequential("SelfClearingMap and SelfClearingSet", () => {
+    it.sequential("should remove expired entries", async () => {
+        const map = new SelfClearingMap<string, number>(1000);
+        const set = new SelfClearingSet<string>(1000);
+
+        await vi.advanceTimersToNextTimerAsync();
+        map.set("a", 0);
+        set.insert("a");
+
+        expect(map.has("a")).to.equal(true);
+        expect(set.has("a")).to.equal(true);
+
+        await moveForwardBy(1000);
+
+        expect(map.has("a")).to.equal(false);
+        expect(set.has("a")).to.equal(false);
+    });
+});

--- a/src/utils/__tests__/containers.ts
+++ b/src/utils/__tests__/containers.ts
@@ -1,0 +1,136 @@
+import { describe, expect, beforeEach, vi, it } from "vitest";
+import { SelfClearingMap, SelfClearingSet } from "../containers.js";
+
+import { setFlagsFromString } from "v8";
+import { runInNewContext } from "vm";
+import { afterEach } from "node:test";
+
+/**
+ * Ensure we garbage collect the maps between tests, otherwise we might get false failures
+ */
+let gc: () => void = global.gc as unknown as () => void;
+if (!(gc as unknown as boolean)) {
+    setFlagsFromString("--expose_gc");
+    gc = runInNewContext("gc"); // nocommit
+}
+
+async function moveForwardBy(time: number) {
+    vi.setSystemTime(vi.getMockedSystemTime()?.getTime() || 0 + time);
+    return vi.advanceTimersByTimeAsync(time);
+}
+
+describe.sequential("SelfClearingMap", () => {
+    beforeEach(() => {
+        // tell vitest we use mocked timers
+        vi.useFakeTimers({ toFake: ["nextTick", "setTimeout", "setImmediate", "Date"] });
+        vi.setSystemTime(0);
+    });
+    afterEach(() => {
+        gc();
+        vi.runOnlyPendingTimers();
+        gc();
+        vi.runOnlyPendingTimers();
+        gc();
+        vi.clearAllTimers();
+        gc();
+    });
+
+    it.sequential("should remove expired entries", async () => {
+        const map = new SelfClearingMap<string, number>(1000);
+        await vi.advanceTimersToNextTimerAsync();
+        map.set("a", 0);
+
+        expect(map.has("a")).to.equal(true);
+
+        await moveForwardBy(1000);
+
+        expect(map.has("a")).to.equal(false);
+    });
+
+    it.sequential("should not remove non-expired entries", async () => {
+        const map = new SelfClearingMap<string, number>(1000);
+        await vi.advanceTimersToNextTimerAsync();
+        map.set("a", 0);
+        expect(map.has("a")).to.equal(true);
+
+        await moveForwardBy(500);
+
+        expect(map.has("a")).to.equal(true);
+    });
+
+    it.sequential("should not remove non-expired entries", async () => {
+        const map = new SelfClearingMap<string, number>(2000, 1000);
+        await vi.advanceTimersToNextTimerAsync();
+        map.set("a", 0);
+        expect(map.has("a")).to.equal(true);
+
+        await moveForwardBy(1000);
+
+        expect(map.has("a")).to.equal(true);
+    });
+
+    /**
+     * TODO: Add more tests, specifically for the timer logic and multiple maps
+     */
+});
+
+describe.sequential("SelfClearingSet", () => {
+    beforeEach(() => {
+        // tell vitest we use mocked timers
+        vi.useFakeTimers({ toFake: ["nextTick", "setTimeout", "setImmediate", "Date"] });
+        vi.setSystemTime(0);
+    });
+    afterEach(() => {
+        gc();
+        vi.runOnlyPendingTimers();
+        gc();
+        vi.runOnlyPendingTimers();
+        gc();
+        vi.clearAllTimers();
+        gc();
+    });
+
+    it.sequential("should remove expired entries", async () => {
+        const set = new SelfClearingSet<string>(1000);
+        await vi.advanceTimersToNextTimerAsync();
+        set.insert("a");
+
+        expect(set.has("a")).to.equal(true);
+
+        await moveForwardBy(1000);
+
+        expect(set.has("a")).to.equal(false);
+    });
+
+    it.sequential("shouldn't remove unexpired entries", async () => {
+        const set = new SelfClearingSet<string>(1000);
+        await vi.advanceTimersToNextTimerAsync();
+        set.insert("a");
+
+        expect(set.has("a")).to.equal(true);
+
+        await moveForwardBy(500);
+
+        expect(set.has("a")).to.equal(true);
+    });
+
+    it.sequential("shouldn't remove unexpired entries", async () => {
+        const set = new SelfClearingSet<string>(2000, 1000);
+        await vi.advanceTimersToNextTimerAsync();
+        set.insert("a");
+
+        expect(set.has("a")).to.equal(true);
+
+        await moveForwardBy(1000);
+
+        expect(set.has("a")).to.equal(true);
+    });
+
+    /**
+     * TODO: Add more tests, specifically for the timer logic and multiple sets
+     */
+});
+
+/**
+ * TODO: Add more tests, specifically for sets and maps together
+ */

--- a/src/utils/__tests__/containers.ts
+++ b/src/utils/__tests__/containers.ts
@@ -1,6 +1,5 @@
 import { describe, expect, beforeEach, afterEach, vi, it } from "vitest";
-import { SelfClearingMap, SelfClearingSet, force_clear_containers } from "../containers.js";
-import * as p_timers from "node:timers/promises";
+import { SelfClearingMap, SelfClearingSet } from "../containers.js";
 
 import { setFlagsFromString } from "v8";
 import { runInNewContext } from "vm";
@@ -21,18 +20,19 @@ async function moveForwardBy(time: number) {
 describe.sequential("SelfClearingMap", () => {
     beforeEach(() => {
         // tell vitest we use mocked timers
-        vi.useFakeTimers({ toFake: ["nextTick", "setTimeout", "setImmediate", "Date", "setInterval"] });
+        vi.useFakeTimers();
         vi.setSystemTime(0);
     });
     afterEach(async () => {
-        await force_clear_containers();
-        await p_timers.setImmediate();
-        await force_clear_containers();
+        gc();
+        vi.runOnlyPendingTimers();
+        gc();
     });
 
     it.sequential("should remove expired entries", async () => {
         const map = new SelfClearingMap<string, number>(1000);
         await vi.advanceTimersToNextTimerAsync();
+        vi.setSystemTime(0);
         map.set("a", 0);
 
         expect(map.has("a")).to.equal(true);
@@ -45,6 +45,7 @@ describe.sequential("SelfClearingMap", () => {
     it.sequential("should not remove non-expired entries", async () => {
         const map = new SelfClearingMap<string, number>(1000);
         await vi.advanceTimersToNextTimerAsync();
+        vi.setSystemTime(0);
         map.set("a", 0);
         expect(map.has("a")).to.equal(true);
 
@@ -70,12 +71,14 @@ describe.sequential("SelfClearingMap", () => {
         map.on_remove = on_remove;
 
         await vi.advanceTimersToNextTimerAsync();
+        vi.setSystemTime(0);
         map.set("a", 0);
 
         expect(map.has("a")).to.equal(true);
         expect(on_remove).not.toHaveBeenCalled();
 
         await moveForwardBy(1002);
+        expect(map.has("a")).to.equal(false);
 
         expect(on_remove).toHaveBeenCalled();
     });
@@ -102,43 +105,6 @@ describe.sequential("SelfClearingMap", () => {
         await moveForwardBy(2000);
         expect(spy).toBeCalledTimes(3);
         expect(spy2).toHaveBeenCalledTimes(1);
-    });
-
-    it.sequential("Should compute the correct time to the next sweep", async () => {
-        const map = new SelfClearingMap<string, number>(1000);
-
-        vi.setSystemTime(500);
-        expect(map.next_interval()).to.equal(500);
-
-        vi.setSystemTime(995);
-        expect(map.next_interval()).to.equal(1005);
-
-        vi.setSystemTime(1000);
-        expect(map.next_interval()).to.equal(1000);
-    });
-
-    it.sequential("Should decide whether to run the sweep correctly", async () => {
-        const map = new SelfClearingMap<string, number>(1000);
-        await vi.advanceTimersToNextTimerAsync();
-
-        vi.setSystemTime(500);
-        expect(map.should_run()).to.equal(false);
-
-        vi.setSystemTime(1000);
-        expect(map.should_run()).to.equal(true);
-
-        vi.setSystemTime(1001);
-        expect(map.should_run()).to.equal(true);
-
-        vi.setSystemTime(995);
-        expect(map.should_run()).to.equal(false);
-
-        vi.setSystemTime(1995);
-        expect(map.should_run()).to.equal(true);
-        map.sweep();
-
-        vi.setSystemTime(2000);
-        expect(map.should_run()).to.equal(false);
     });
 });
 
@@ -193,14 +159,12 @@ describe.sequential("SelfClearingSet", () => {
     it.sequential("Should call the on_remove callback", async () => {
         const on_remove = vi.fn();
         const set = new SelfClearingSet<string>(1000, 1000, on_remove);
-
-        await vi.advanceTimersToNextTimerAsync();
         set.insert("a");
 
         expect(set.has("a")).to.equal(true);
         expect(on_remove).not.toHaveBeenCalled();
 
-        await moveForwardBy(1002);
+        await moveForwardBy(1000);
 
         expect(set.has("a")).to.equal(false);
         expect(on_remove).toHaveBeenCalled();
@@ -229,50 +193,19 @@ describe.sequential("SelfClearingSet", () => {
         expect(spy).toBeCalledTimes(3);
         expect(spy2).toHaveBeenCalledTimes(1);
     });
-
-    it.sequential("Should compute the correct time to the next sweep", async () => {
-        const set = new SelfClearingSet<string>(1000);
-
-        vi.setSystemTime(500);
-        expect(set.next_interval()).to.equal(500);
-
-        vi.setSystemTime(995);
-        expect(set.next_interval()).to.equal(1005);
-
-        vi.setSystemTime(1000);
-        expect(set.next_interval()).to.equal(1000);
-    });
-
-    it.sequential("Should decide whether to run the sweep correctly", async () => {
-        const set = new SelfClearingSet<string>(1000);
-        await vi.advanceTimersToNextTimerAsync();
-
-        vi.setSystemTime(500);
-        expect(set.should_run()).to.equal(false);
-
-        vi.setSystemTime(1000);
-        expect(set.should_run()).to.equal(true);
-
-        vi.setSystemTime(1001);
-        expect(set.should_run()).to.equal(true);
-
-        vi.setSystemTime(995);
-        expect(set.should_run()).to.equal(false);
-
-        vi.setSystemTime(1995);
-        expect(set.should_run()).to.equal(true);
-        set.sweep();
-
-        vi.setSystemTime(2000);
-        expect(set.should_run()).to.equal(false);
-    });
 });
 
-/**
- * TODO: Add more tests, specifically for sets and maps together
- */
-
 describe.sequential("SelfClearingMap and SelfClearingSet", () => {
+    beforeEach(() => {
+        // tell vitest we use mocked timers
+        vi.useFakeTimers({ toFake: ["nextTick", "setTimeout", "setImmediate", "Date"] });
+        vi.setSystemTime(0);
+    });
+    afterEach(async () => {
+        gc();
+        vi.runOnlyPendingTimers();
+        gc();
+    });
     it.sequential("should remove expired entries", async () => {
         const map = new SelfClearingMap<string, number>(1000);
         const set = new SelfClearingSet<string>(1000);
@@ -284,7 +217,7 @@ describe.sequential("SelfClearingMap and SelfClearingSet", () => {
         expect(map.has("a")).to.equal(true);
         expect(set.has("a")).to.equal(true);
 
-        await moveForwardBy(1000);
+        await moveForwardBy(1002);
 
         expect(map.has("a")).to.equal(false);
         expect(set.has("a")).to.equal(false);

--- a/src/utils/__tests__/containers.ts
+++ b/src/utils/__tests__/containers.ts
@@ -190,7 +190,7 @@ describe.sequential("SelfClearingSet", () => {
         expect(set.has("a")).to.equal(true);
     });
 
-    it.sequential.only("Should call the on_remove callback", async () => {
+    it.sequential("Should call the on_remove callback", async () => {
         const on_remove = vi.fn();
         const set = new SelfClearingSet<string>(1000, 1000, on_remove);
 

--- a/src/utils/__tests__/containers.ts
+++ b/src/utils/__tests__/containers.ts
@@ -1,9 +1,8 @@
-import { describe, expect, beforeEach, vi, it } from "vitest";
+import { describe, expect, beforeEach, afterEach, vi, it } from "vitest";
 import { SelfClearingMap, SelfClearingSet } from "../containers.js";
 
 import { setFlagsFromString } from "v8";
 import { runInNewContext } from "vm";
-import { afterEach } from "node:test";
 
 /**
  * Ensure we garbage collect the maps between tests, otherwise we might get false failures
@@ -15,7 +14,7 @@ if (!(gc as unknown as boolean)) {
 }
 
 async function moveForwardBy(time: number) {
-    vi.setSystemTime(vi.getMockedSystemTime()?.getTime() || 0 + time);
+    vi.setSystemTime((vi.getMockedSystemTime()?.getTime() || 0) + time);
     return vi.advanceTimersByTimeAsync(time);
 }
 
@@ -28,10 +27,6 @@ describe.sequential("SelfClearingMap", () => {
     afterEach(() => {
         gc();
         vi.runOnlyPendingTimers();
-        gc();
-        vi.runOnlyPendingTimers();
-        gc();
-        vi.clearAllTimers();
         gc();
     });
 
@@ -63,8 +58,10 @@ describe.sequential("SelfClearingMap", () => {
         await vi.advanceTimersToNextTimerAsync();
         map.set("a", 0);
         expect(map.has("a")).to.equal(true);
+        console.log(map);
 
         await moveForwardBy(1000);
+        console.log(vi.getMockedSystemTime()?.getTime());
 
         expect(map.has("a")).to.equal(true);
     });
@@ -83,10 +80,6 @@ describe.sequential("SelfClearingSet", () => {
     afterEach(() => {
         gc();
         vi.runOnlyPendingTimers();
-        gc();
-        vi.runOnlyPendingTimers();
-        gc();
-        vi.clearAllTimers();
         gc();
     });
 
@@ -110,6 +103,7 @@ describe.sequential("SelfClearingSet", () => {
         expect(set.has("a")).to.equal(true);
 
         await moveForwardBy(500);
+        console.log(vi.getMockedSystemTime()?.getTime());
 
         expect(set.has("a")).to.equal(true);
     });

--- a/src/utils/containers.ts
+++ b/src/utils/containers.ts
@@ -8,6 +8,7 @@ let containers: WeakRef<SelfClearingContainer>[] = [];
 
 function sweep_containers() {
     containers = containers.filter(c => c.deref() !== undefined);
+    set_next_interval();
     for (const container of containers) {
         if (container.deref()!.should_run()) {
             // 50ms buffer
@@ -21,8 +22,6 @@ function sweep_containers() {
         next_interval = Infinity;
         return;
     }
-
-    set_next_interval();
 }
 
 function set_next_interval() {

--- a/src/utils/containers.ts
+++ b/src/utils/containers.ts
@@ -24,13 +24,19 @@ function set_clearing_interval(container: WeakRef<SelfClearingContainer>, interv
         }
         container_ref = undefined;
     }, interval_time);
+    return interval;
 }
 
 abstract class SelfClearingContainer {
+    private interval_ref: NodeJS.Timeout | null = null;
     constructor(protected interval: number) {
-        set_clearing_interval(new WeakRef(this), interval);
+        this.interval_ref = set_clearing_interval(new WeakRef(this), interval);
     }
-    destroy() {}
+    destroy() {
+        if (this.interval_ref !== null) {
+            clear_interval(this.interval_ref);
+        }
+    }
     abstract sweep(): void;
 }
 

--- a/src/utils/containers.ts
+++ b/src/utils/containers.ts
@@ -12,7 +12,6 @@ function set_clearing_interval(container: WeakRef<SelfClearingContainer>, interv
         let container_ref = container.deref();
         if (cleared && !had_error) {
             // This is a warning because it's a sign of cleanup not happening properly, but it's not a critical error
-            // Also, it happens in tests, for some reason
             M.warn(`Running cleared interval ${interval} at ${new Error().stack}`);
             had_error = true;
             return;

--- a/src/utils/containers.ts
+++ b/src/utils/containers.ts
@@ -49,6 +49,12 @@ export class SelfClearingSet<T> extends SelfClearingContainer {
         this.duration = duration;
         this.on_remove = on_remove;
     }
+    override destroy() {
+        super.destroy();
+        for (const [value, _] of this.contents) {
+            this.on_remove(value);
+        }
+    }
     override sweep() {
         const now = Date.now();
         for (const [value, timestamp] of this.contents) {

--- a/src/utils/containers.ts
+++ b/src/utils/containers.ts
@@ -10,17 +10,18 @@ function set_clearing_interval(container: WeakRef<SelfClearingContainer>, interv
     let cleared = false;
     const interval: NodeJS.Timeout | null = set_interval(() => {
         let container_ref = container.deref();
-        if (container_ref) {
-            container_ref.sweep();
-        } else if (interval !== null) {
-            clear_interval(interval);
-            cleared = true;
-        }
         if (cleared && !had_error) {
             // This is a warning because it's a sign of cleanup not happening properly, but it's not a critical error
             // Also, it happens in tests, for some reason
             M.warn(`Running cleared interval ${interval} at ${new Error().stack}`);
             had_error = true;
+            return;
+        }
+        if (container_ref) {
+            container_ref.sweep();
+        } else if (interval !== null) {
+            clear_interval(interval);
+            cleared = true;
         }
         container_ref = undefined;
     }, interval_time);

--- a/src/utils/containers.ts
+++ b/src/utils/containers.ts
@@ -68,7 +68,9 @@ export class SelfClearingSet<T> extends SelfClearingContainer {
         this.contents.set(value, Date.now());
     }
     remove(value: T) {
-        this.on_remove(value);
+        if (this.has(value)) {
+            this.on_remove(value);
+        }
         this.contents.delete(value);
     }
     has(value: T) {
@@ -129,7 +131,9 @@ export class SelfClearingMap<K, V> extends SelfClearingContainer {
     }
     */
     remove(key: K) {
-        this.on_remove(key, this.contents.get(key)![1]);
+        if (this.has(key)) {
+            this.on_remove(key, this.contents.get(key)![1]);
+        }
         this.contents.delete(key);
     }
     has(key: K) {

--- a/src/utils/containers.ts
+++ b/src/utils/containers.ts
@@ -1,56 +1,17 @@
 import { strict as assert } from "assert";
 import { critical_error, M } from "./debugging-and-logging.js";
-import { clear_timeout, set_timeout } from "./node.js";
+import { set_interval, clear_interval, clear_timeout, set_timeout } from "./node.js";
 
-let interval_timeout: NodeJS.Timeout | null = null;
-let next_interval: number = Infinity;
-const containers: WeakRef<SelfClearingContainer>[] = [];
-function sweep_containers() {
-    for (const container of containers) {
-        if (container.deref()!.next_interval() <= 50) {
-            // 50ms buffer
-            container.deref()!.sweep();
-        } else if (container.deref() === undefined) {
-            containers.splice(containers.indexOf(container), 1);
-        }
-    }
-
-    if (containers.length === 0) {
-        // No more containers, stop the interval
-        interval_timeout = null;
-        next_interval = Infinity;
-        return;
-    }
-
-    next_interval = Math.min(...containers.map(c => c.deref()!.next_interval()).map(n => (n > 50 ? n : 50)));
-    const timeout_setter = () => set_timeout(sweep_containers, next_interval);
-    process.nextTick(timeout_setter); // Unroll the stack, so we don't get a stack overflow
-}
-
-abstract class SelfClearingContainer {
-    private start_time: number;
-    constructor(private interval: number) {
-        this.interval = interval;
-        this.start_time = Date.now();
-        containers.push(new WeakRef(this));
-        if (!interval_timeout || next_interval > interval) {
-            clear_timeout(interval_timeout!);
-            sweep_containers();
-        }
-    }
-    destroy() {}
-    abstract sweep(): void;
-    next_interval(): number {
-        return (Date.now() - this.start_time) % this.interval;
-    }
-}
-
-export class SelfClearingSet<T> extends SelfClearingContainer {
+export class SelfClearingSet<T> {
     contents = new Map<T, number>();
     duration: number;
+    interval: NodeJS.Timeout;
     constructor(duration: number, interval?: number) {
-        super(interval ?? duration);
         this.duration = duration;
+        this.interval = set_interval(this.sweep.bind(this), interval ?? this.duration);
+    }
+    destroy() {
+        clear_interval(this.interval);
     }
     sweep() {
         const now = Date.now();
@@ -74,17 +35,18 @@ export class SelfClearingSet<T> extends SelfClearingContainer {
     }
 }
 
-export class SelfClearingMap<K, V> extends SelfClearingContainer {
+export class SelfClearingMap<K, V> {
     contents = new Map<K, [number, V]>();
     duration: number;
+    interval: NodeJS.Timeout;
     on_remove?: (key: K, value: V) => void;
     constructor(duration: number, interval?: number, on_remove?: (key: K, value: V) => void) {
-        super(interval ?? duration);
         this.duration = duration;
+        this.interval = set_interval(this.sweep.bind(this), interval ?? this.duration);
         this.on_remove = on_remove;
     }
-    override destroy() {
-        super.destroy();
+    destroy() {
+        clear_interval(this.interval);
         if (this.on_remove) {
             for (const [key, [_, value]] of this.contents) {
                 this.on_remove(key, value);

--- a/test/containers.ts
+++ b/test/containers.ts
@@ -10,7 +10,7 @@ import { runInNewContext } from "vm";
 let gc: () => void = global.gc as unknown as () => void;
 if (!(gc as unknown as boolean)) {
     setFlagsFromString("--expose_gc");
-    gc = runInNewContext("gc"); // nocommit
+    gc = runInNewContext("gc");
 }
 
 async function moveForwardBy(time: number) {

--- a/test/containers.ts
+++ b/test/containers.ts
@@ -1,5 +1,5 @@
 import { describe, expect, beforeEach, afterEach, vi, it } from "vitest";
-import { SelfClearingMap, SelfClearingSet } from "../containers.js";
+import { SelfClearingMap, SelfClearingSet } from "../src/utils/containers.js";
 
 import { setFlagsFromString } from "v8";
 import { runInNewContext } from "vm";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
     test: {
-        include: ["test/**/*.ts"],
-        exclude: [],
+        include: ["test/**/*.ts", "**/__tests__/**/*.ts"],
+        exclude: ["**/node_modules/**"],
     },
 });


### PR DESCRIPTION
I made this little code change to have a global data cleanup timer for *all* `SelfClearingSet` and `SelfClearingMap`, which allows easier cleanup without having to call `.destroy`.

TODO:

- [x] Test performance
- [x] Test if this function works correctly