### PR TITLE
Fix various wording problems with template-instantiation article

### DIFF
--- a/wiki-articles/template-instantiation.md
+++ b/wiki-articles/template-instantiation.md
@@ -1,14 +1,14 @@
 # What Is Template Instantiation?
 
-Templates are not real entities until a piece of code uses them with arguments.
+Templates are not real functions until a piece of code uses them with arguments.
 When this happens, the compiler replaces the template parameters with the
-provided arguments, deriving the generic code into specific code.
+provided arguments, turning the generic code into specific code.
 
 The generic code needs to be available in any translation unit that uses it. This
 is why templates are typically declared **and** defined entirely in headers.
 
 <!-- inline -->
-## Template function
+## Function template
 ```cpp
 template<typename T>
 void print(T arg) {


### PR DESCRIPTION
A few things in the article aren't quite right and should be corrected:

1. A template is an [entity](https://eel.is/c++draft/basic.pre#def:entity) by definition. However, it would be correct to say that a function template is not a function.

2. To my knowledge, "deriving to" or "deriving into" isn't correct English. However, you can say "turning into", which most would consider simpler language anyway.

3. It's called "function template", but the heading says "template function". We don't need to be pedantically correct in these articles, but at least we should use the terminology from the standard/cppreference.