### PR TITLE
Improve wording of template-argument-deduction article

### DIFF
--- a/wiki-articles/template-argument-deduction.md
+++ b/wiki-articles/template-argument-deduction.md
@@ -4,7 +4,7 @@ Sometimes, it is possible to omit template arguments when using a template,
 letting the compiler infer them instead.
 
 <!-- inline -->
-## Template function
+## Function template
 ```cpp
 template<typename T>
 void print(T arg) {
@@ -21,12 +21,12 @@ print<std::string>("Hi");
 ```
 
 ## Deduction
-In the first two calls to `print`, no template argument is provided. Since `print`
-takes a parameter of type `T`, the compiler can match `T` to the type of
+In the first two calls to `print`, no template argument is explicitly specified.
+Since `print` takes a parameter of type `T`, the compiler can deduce `T` from the type of
 the provided arguments: `int` for `42`, and `const char*` for `"Hello"`.
 
-The third call inhibits deduction by imposing `T`. A `std::string` is constructed
-from `"Hi"`, and a copy of it is passed to the function.
+The third call inhibits deduction by explicitly specifying `T`.
+A `std::string` is constructed from `"Hi"` and passed to the function.
 
 The compiler cannot always deduce template parameters, for example when they
 appear only in the return type of a function:
@@ -53,7 +53,7 @@ Foo bar = make(45);
 Template parameters can be partially deduced independently of each other:
 
 <!-- inline -->
-## Template function
+## Function template
 ```cpp
 template<class T, class A>
 T make(A arg) {


### PR DESCRIPTION
The following fixes/improvements are made:

1. "Function template" is the right term; see https://eel.is/c++draft/temp.fct

2. The standard term to describe "providing" template arguments is "explicitly specifying"; see https://eel.is/c++draft/temp.arg.explicit. The article once calls this "not provided" and once calls it "imposing". Instead of inventing new words for this (and being inconsistent within the same article), let's just use the standard terminology.

3. "Match `T` to" can be replaced with "deduce `T` from". Since the article is already talking about template argument deduction, it only makes sense to use the standard terminology. On top of that, the article later says "deduce template parameters", so it does use standard terminology, just not consistently.

4. It is not true that "a `std::string` is constructed ... and a copy is passed ...". At least since C++17 (not sure about before), there is only a `std::string` parameter object; no additional copies are made. There is only a single `std::string` in that call.