### PR TITLE
Refactor logging

### DIFF
--- a/src/command-abstractions/text-based-command-descriptor.ts
+++ b/src/command-abstractions/text-based-command-descriptor.ts
@@ -5,7 +5,6 @@ import * as Discord from "discord.js";
 import { unwrap } from "../utils/misc.js";
 import { build_description, escape_regex, wrap } from "../utils/strings.js";
 import { zip } from "../utils/iterables.js";
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { M } from "../utils/debugging-and-logging.js";
 import {
     TextBasedCommandParameterOptions,
@@ -34,7 +33,7 @@ export class BotTextBasedCommand<Args extends unknown[] = []> extends BaseBotInt
         builder: TextBasedCommandBuilder<Args, true, true> | TextBasedCommandBuilder<Args, true, false, true>,
         protected readonly wheatley: Wheatley,
     ) {
-        super(name, builder.handler ?? (async () => critical_error("This shouldn't happen")));
+        super(name, builder.handler ?? (async () => wheatley.critical_error("This shouldn't happen")));
         this.options = builder.options;
         if (builder.type === "top-level") {
             this.subcommands = new Discord.Collection();
@@ -213,7 +212,7 @@ export class BotTextBasedCommand<Args extends unknown[] = []> extends BaseBotInt
                         command_options.push(reply_message.author);
                     } catch (e) {
                         await reply_with_error(`Error fetching reply`, true);
-                        critical_error(e);
+                        this.wheatley.critical_error(e);
                         return;
                     }
                 } else if (!option.required) {

--- a/src/command-abstractions/text-based-command.ts
+++ b/src/command-abstractions/text-based-command.ts
@@ -6,7 +6,6 @@ import { unwrap } from "../utils/misc.js";
 import { is_string } from "../utils/strings.js";
 import { Wheatley } from "../wheatley.js";
 import { BotTextBasedCommand } from "./text-based-command-descriptor.js";
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { forge_snowflake } from "../utils/discord.js";
 
 export type CommandAbstractionReplyOptions = {
@@ -260,7 +259,7 @@ export class TextBasedCommand {
                     const reply_message = await this.wheatley.fetch_message_reply(this.reply_object);
                     return reply_message;
                 } catch (e) {
-                    critical_error(e);
+                    this.wheatley.critical_error(e);
                 }
             }
         }

--- a/src/components/anti-autoreact.ts
+++ b/src/components/anti-autoreact.ts
@@ -13,7 +13,7 @@ export default class AntiAutoreact extends BotComponent {
 
     override async on_ready() {
         this.obnoxious_autoreact_immunity = new Set([
-            this.wheatley.zelis.id,
+            "199943082441965577", // Zelis
             "551519630578024468", // Swyde
         ]);
     }

--- a/src/components/anti-everyone.ts
+++ b/src/components/anti-everyone.ts
@@ -2,7 +2,6 @@ import * as Discord from "discord.js";
 import { BotComponent } from "../bot-component.js";
 import { Wheatley } from "../wheatley.js";
 import { colors, MINUTE, HOUR } from "../common.js";
-import { M } from "../utils/debugging-and-logging.js";
 import { SelfClearingMap } from "../utils/containers.js";
 import { unwrap } from "../utils/misc.js";
 

--- a/src/components/anti-executable.ts
+++ b/src/components/anti-executable.ts
@@ -3,7 +3,6 @@ import * as https from "https";
 
 import { strict as assert } from "assert";
 
-import { M, critical_error } from "../utils/debugging-and-logging.js";
 import { colors } from "../common.js";
 import { BotComponent } from "../bot-component.js";
 import { Wheatley } from "../wheatley.js";
@@ -143,7 +142,7 @@ export default class AntiExecutable extends BotComponent {
                 try {
                     file_buffer = await this.fetch(attachment.url);
                 } catch (e) {
-                    critical_error(e);
+                    this.wheatley.critical_error(e);
                     return;
                 }
                 // virustotal

--- a/src/components/anti-self-star.ts
+++ b/src/components/anti-self-star.ts
@@ -1,7 +1,6 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
 import { departialize } from "../utils/discord.js";
-import { M } from "../utils/debugging-and-logging.js";
 import { BotComponent } from "../bot-component.js";
 import { Wheatley } from "../wheatley.js";
 import { has_media } from "./autoreact.js";

--- a/src/components/buzzwords.ts
+++ b/src/components/buzzwords.ts
@@ -1,7 +1,6 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
 import { round, unwrap } from "../utils/misc.js";
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { SelfClearingSet } from "../utils/containers.js";
 import { M } from "../utils/debugging-and-logging.js";
 import { MINUTE, colors } from "../common.js";
@@ -186,7 +185,7 @@ export default class Buzzwords extends BotComponent {
             //}, MINUTE);
             await this.reflowRoles();
             this.interval = set_interval(() => {
-                this.reflowRoles().catch(critical_error);
+                this.reflowRoles().catch(this.wheatley.critical_error.bind(this.wheatley));
             }, 10 * MINUTE);
         }
     }

--- a/src/components/code.ts
+++ b/src/components/code.ts
@@ -2,7 +2,7 @@ import * as Discord from "discord.js";
 
 import { strict as assert } from "assert";
 
-import { M, ignorable_error } from "../utils/debugging-and-logging.js";
+import { M } from "../utils/debugging-and-logging.js";
 import { colors } from "../common.js";
 import { BotComponent } from "../bot-component.js";
 import { Wheatley, create_error_reply } from "../wheatley.js";
@@ -43,7 +43,7 @@ export default class Code extends BotComponent {
                         return;
                     }
                 } catch (e) {
-                    ignorable_error(e);
+                    this.wheatley.ignorable_error(e);
                 }
             }
             // Check for a user trying to format a string

--- a/src/components/core-guidelines.ts
+++ b/src/components/core-guidelines.ts
@@ -2,7 +2,6 @@ import * as Discord from "discord.js";
 
 import * as fs from "fs";
 
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { M } from "../utils/debugging-and-logging.js";
 
 import { Index, IndexEntry } from "../algorithm/search.js";
@@ -80,7 +79,7 @@ export default class CoreGuidelines extends BotComponent {
         );
 
         // Ok if the bot spins up while this is loading
-        this.index.load_data().catch(critical_error);
+        this.index.load_data().catch(this.wheatley.critical_error.bind(this.wheatley));
     }
 
     async guide(command: TextBasedCommand, query: string) {

--- a/src/components/cppref.ts
+++ b/src/components/cppref.ts
@@ -5,7 +5,6 @@ import { strict as assert } from "assert";
 import * as fs from "fs";
 
 import { format_list } from "../utils/strings.js";
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { M } from "../utils/debugging-and-logging.js";
 
 import { cppref_index, cppref_page, CpprefSubIndex } from "../../indexes/cppref/types.js";
@@ -177,7 +176,7 @@ export default class Cppref extends BotComponent {
         );
 
         // Ok if the bot spins up while this is loading
-        this.index.load_data().catch(critical_error);
+        this.index.load_data().catch(this.wheatley.critical_error.bind(this.wheatley));
     }
 
     async cppref(command: TextBasedCommand, query: string) {

--- a/src/components/days-since-last-incident.ts
+++ b/src/components/days-since-last-incident.ts
@@ -4,7 +4,6 @@ import { strict as assert } from "assert";
 
 import { BotComponent } from "../bot-component.js";
 import { Wheatley } from "../wheatley.js";
-import { critical_error, M } from "../utils/debugging-and-logging.js";
 import { unwrap } from "../utils/misc.js";
 import { time_to_human } from "../utils/strings.js";
 import { MINUTE } from "../common.js";
@@ -69,13 +68,13 @@ export default class DaysSinceLastIncident extends BotComponent {
             });
         }
         this.timer = set_interval(() => {
-            this.update_or_send_if_needed().catch(critical_error);
+            this.update_or_send_if_needed().catch(this.wheatley.critical_error.bind(this.wheatley));
         }, MINUTE);
     }
 
     handle_incident(moderation: moderation_entry) {
         (async () => {
             await this.update_or_send_if_needed();
-        })().catch(critical_error);
+        })().catch(this.wheatley.critical_error.bind(this.wheatley));
     }
 }

--- a/src/components/format.ts
+++ b/src/components/format.ts
@@ -6,7 +6,6 @@ import { RequestInfo, RequestInit } from "node-fetch";
 const fetch = (url: RequestInfo, init?: RequestInit) =>
     import("node-fetch").then(({ default: fetch }) => fetch(url, init));
 
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { M } from "../utils/debugging-and-logging.js";
 import { BotComponent } from "../bot-component.js";
 import { Wheatley } from "../wheatley.js";
@@ -286,11 +285,11 @@ export default class Format extends BotComponent {
                 }
             }
         } catch (e) {
-            critical_error(e);
+            this.wheatley.critical_error(e);
             try {
                 await message.reply("Internal error while running !f");
             } catch (e) {
-                critical_error(e);
+                this.wheatley.critical_error(e);
             }
         }
     }

--- a/src/components/forum-channels.ts
+++ b/src/components/forum-channels.ts
@@ -1,7 +1,6 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
 import { decode_snowflake, fetch_all_threads_archive_count, get_tag } from "../utils/discord.js";
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { SelfClearingSet } from "../utils/containers.js";
 import { M } from "../utils/debugging-and-logging.js";
 import { colors, DAY, HOUR, MINUTE } from "../common.js";
@@ -94,7 +93,7 @@ export default class ForumChannels extends BotComponent {
         // thread.lastMessageId can be null if there are no messages (possibly and the forum starter has been deleted)
         // if the thread author hasn't sent an initial message it'll mess things up, this needs manual review
         if (thread.lastMessageId == null) {
-            await this.wheatley.zelis.send(`thread.lastMessageId is null for ${thread.url}`);
+            this.wheatley.alert(`thread.lastMessageId is null for ${thread.url}`);
             return;
         }
         const now = Date.now();
@@ -196,7 +195,7 @@ export default class ForumChannels extends BotComponent {
         await this.forum_cleanup();
         // every hour try to cleanup
         this.interval = set_interval(() => {
-            this.forum_cleanup().catch(critical_error);
+            this.forum_cleanup().catch(this.wheatley.critical_error.bind(this.wheatley));
         }, 60 * MINUTE);
     }
 
@@ -226,7 +225,7 @@ export default class ForumChannels extends BotComponent {
                         this.timeout_map.set(
                             thread.id,
                             set_timeout(() => {
-                                this.prompt_close(thread).catch(critical_error);
+                                this.prompt_close(thread).catch(this.wheatley.critical_error.bind(this.wheatley));
                             }, thank_you_timeout),
                         );
                         this.possibly_resolved.insert(thread.id);
@@ -241,7 +240,7 @@ export default class ForumChannels extends BotComponent {
                 this.timeout_map.set(
                     thread.id,
                     set_timeout(() => {
-                        this.prompt_close(thread).catch(critical_error);
+                        this.prompt_close(thread).catch(this.wheatley.critical_error.bind(this.wheatley));
                     }, thank_you_timeout),
                 );
             }

--- a/src/components/google.ts
+++ b/src/components/google.ts
@@ -2,7 +2,6 @@ import * as Discord from "discord.js";
 
 import { strict as assert } from "assert";
 
-import { M } from "../utils/debugging-and-logging.js";
 import { colors } from "../common.js";
 import { BotComponent } from "../bot-component.js";
 import { Wheatley } from "../wheatley.js";

--- a/src/components/man7.ts
+++ b/src/components/man7.ts
@@ -4,7 +4,6 @@ import { strict as assert } from "assert";
 
 import * as fs from "fs";
 
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { M } from "../utils/debugging-and-logging.js";
 
 import { Index, IndexEntry } from "../algorithm/search.js";
@@ -114,7 +113,7 @@ export default class Man7 extends BotComponent {
         );
 
         // Ok if the bot spins up while this is loading
-        this.index.load_data().catch(critical_error);
+        this.index.load_data().catch(this.wheatley.critical_error.bind(this.wheatley));
     }
 
     async man(command: TextBasedCommand, query: string) {

--- a/src/components/massban.ts
+++ b/src/components/massban.ts
@@ -1,6 +1,5 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { M } from "../utils/debugging-and-logging.js";
 import { colors } from "../common.js";
 import { BotComponent } from "../bot-component.js";
@@ -32,7 +31,7 @@ export default class Massban extends BotComponent {
                 }
             }
         } catch (e) {
-            critical_error(e);
+            this.wheatley.critical_error(e);
         }
     }
 

--- a/src/components/moderation/note.ts
+++ b/src/components/moderation/note.ts
@@ -3,8 +3,6 @@ import { strict as assert } from "assert";
 import * as Discord from "discord.js";
 import * as mongo from "mongodb";
 
-import { critical_error } from "../../utils/debugging-and-logging.js";
-import { M } from "../../utils/debugging-and-logging.js";
 import { Wheatley } from "../../wheatley.js";
 import { ModerationComponent } from "./moderation-common.js";
 import { TextBasedCommandBuilder } from "../../command-abstractions/text-based-command-builder.js";
@@ -91,7 +89,7 @@ export default class Note extends ModerationComponent {
             });
         } catch (e) {
             await this.reply_with_error(command, `Error issuing ${this.type}`);
-            critical_error(e);
+            this.wheatley.critical_error(e);
         }
     }
 

--- a/src/components/moderation/warn.ts
+++ b/src/components/moderation/warn.ts
@@ -3,8 +3,6 @@ import { strict as assert } from "assert";
 import * as Discord from "discord.js";
 import * as mongo from "mongodb";
 
-import { critical_error } from "../../utils/debugging-and-logging.js";
-import { M } from "../../utils/debugging-and-logging.js";
 import { Wheatley } from "../../wheatley.js";
 import { ModerationComponent } from "./moderation-common.js";
 import { TextBasedCommandBuilder } from "../../command-abstractions/text-based-command-builder.js";

--- a/src/components/modmail.ts
+++ b/src/components/modmail.ts
@@ -2,7 +2,6 @@ import { strict as assert } from "assert";
 import * as Discord from "discord.js";
 
 import { get_url_for } from "../utils/discord.js";
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { M } from "../utils/debugging-and-logging.js";
 import { colors, HOUR, MINUTE } from "../common.js";
 import { BotComponent } from "../bot-component.js";
@@ -106,7 +105,7 @@ export default class Modmail extends BotComponent {
                 throw e; // rethrow
             }
         } catch (e) {
-            critical_error(e);
+            this.wheatley.critical_error(e);
         }
     }
 
@@ -173,7 +172,7 @@ export default class Modmail extends BotComponent {
                 this.monke_set.set(interaction.user.id, Date.now());
             }
         } catch (e) {
-            critical_error(e);
+            this.wheatley.critical_error(e);
         }
     }
 
@@ -193,7 +192,7 @@ export default class Modmail extends BotComponent {
                         this.monke_set.remove(member.id);
                     }
                 } catch (e) {
-                    critical_error(e);
+                    this.wheatley.critical_error(e);
                 }
             } else {
                 await interaction.reply({

--- a/src/components/modstats.ts
+++ b/src/components/modstats.ts
@@ -6,7 +6,6 @@ import { TextBasedCommandBuilder } from "../command-abstractions/text-based-comm
 import { TextBasedCommand } from "../command-abstractions/text-based-command.js";
 
 import { Wheatley } from "../wheatley.js";
-import { M } from "../utils/debugging-and-logging.js";
 import { colors, DAY } from "../common.js";
 import { unwrap } from "../utils/misc.js";
 import { capitalize } from "../utils/strings.js";

--- a/src/components/notify-about-brand-new-users.ts
+++ b/src/components/notify-about-brand-new-users.ts
@@ -1,8 +1,6 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
 import { time_to_human } from "../utils/strings.js";
-import { critical_error } from "../utils/debugging-and-logging.js";
-import { M } from "../utils/debugging-and-logging.js";
 import { colors, MINUTE } from "../common.js";
 import { BotComponent } from "../bot-component.js";
 import { Wheatley } from "../wheatley.js";
@@ -31,8 +29,9 @@ export default class NotifyAboutBrandNewUsers extends BotComponent {
                 text: `ID: ${member.id}`,
             })
             .setTimestamp();
-        await this.wheatley.channels.welcome.send({ embeds: [embed] }).catch(reason => critical_error(reason));
-        //member_log_channel!.send(`<@!${zelis_id}>`);
+        await this.wheatley.channels.welcome
+            .send({ embeds: [embed] })
+            .catch(reason => this.wheatley.critical_error(reason));
     }
 
     override async on_guild_member_add(member: Discord.GuildMember) {

--- a/src/components/permissions-manager.ts
+++ b/src/components/permissions-manager.ts
@@ -2,7 +2,7 @@ import * as Discord from "discord.js";
 
 import { strict as assert } from "assert";
 
-import { critical_error, M } from "../utils/debugging-and-logging.js";
+import { M } from "../utils/debugging-and-logging.js";
 import { HOUR } from "../common.js";
 import { BotComponent } from "../bot-component.js";
 import { Wheatley } from "../wheatley.js";
@@ -304,9 +304,9 @@ export default class PermissionManager extends BotComponent {
 
     override async on_ready() {
         this.setup_permissions_map();
-        this.set_permissions().catch(critical_error);
+        this.set_permissions().catch(this.wheatley.critical_error.bind(this.wheatley));
         setTimeout(() => {
-            this.set_permissions().catch(critical_error);
+            this.set_permissions().catch(this.wheatley.critical_error.bind(this.wheatley));
         }, HOUR);
     }
 }

--- a/src/components/purge.ts
+++ b/src/components/purge.ts
@@ -2,7 +2,7 @@ import * as Discord from "discord.js";
 
 import { strict as assert } from "assert";
 
-import { M, critical_error } from "../utils/debugging-and-logging.js";
+import { M } from "../utils/debugging-and-logging.js";
 import { HOUR, MINUTE, colors } from "../common.js";
 import { BotComponent } from "../bot-component.js";
 import { Wheatley } from "../wheatley.js";
@@ -203,7 +203,7 @@ export default class Purge extends BotComponent {
             await channel.bulkDelete(messages);
             handled += messages.size;
             last_seen = Math.min(...[...messages.values()].map(message => message.createdTimestamp));
-            command.edit(make_message(false)).catch(critical_error);
+            command.edit(make_message(false)).catch(this.wheatley.critical_error.bind(this.wheatley));
         }
         await command.edit(make_message(true));
         if (unwrap(this.tasks.get(id))[1]) {

--- a/src/components/quote.ts
+++ b/src/components/quote.ts
@@ -3,7 +3,6 @@ import { strict as assert } from "assert";
 import { unwrap } from "../utils/misc.js";
 import { index_of_first_not_satisfying } from "../utils/iterables.js";
 import { decode_snowflake, forge_snowflake, is_media_link_embed } from "../utils/discord.js";
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { M } from "../utils/debugging-and-logging.js";
 import { colors, MINUTE } from "../common.js";
 import { BotComponent } from "../bot-component.js";
@@ -152,7 +151,7 @@ export default class Quote extends BotComponent {
                             .setColor(colors.red)
                             .setDescription("Error: You don't have permissions for that channel"),
                     );
-                    await this.wheatley.zelis.send("quote exploit attempt");
+                    this.wheatley.alert("quote exploit attempt");
                     continue;
                 }
                 let messages: Discord.Message[] = [];
@@ -190,7 +189,7 @@ export default class Quote extends BotComponent {
                 embeds.push(
                     new Discord.EmbedBuilder().setColor(colors.red).setDescription("Error: Channel not a text channel"),
                 );
-                critical_error("Error: Channel not a text channel");
+                this.wheatley.critical_error("Error: Channel not a text channel");
             }
         }
         if (embeds.length > 0) {

--- a/src/components/report.ts
+++ b/src/components/report.ts
@@ -2,7 +2,6 @@ import * as Discord from "discord.js";
 
 import { strict as assert } from "assert";
 
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { SelfClearingMap } from "../utils/containers.js";
 import { M } from "../utils/debugging-and-logging.js";
 import { colors, MINUTE } from "../common.js";
@@ -105,7 +104,7 @@ export default class Report extends BotComponent {
                     "Something went wrong internally due to the report modal not being submitted after a while." +
                     ` Please re-submit the report. Here is your message so you don't have to re-type it:\n${message}`,
             });
-            critical_error("Slow report thing happened");
+            this.wheatley.critical_error("Slow report thing happened");
         }
     }
 }

--- a/src/components/role-manager.ts
+++ b/src/components/role-manager.ts
@@ -2,7 +2,6 @@ import * as Discord from "discord.js";
 import { strict as assert } from "assert";
 import { MINUTE } from "../common.js";
 import { unwrap } from "../utils/misc.js";
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { M } from "../utils/debugging-and-logging.js";
 import { BotComponent } from "../bot-component.js";
 import { Wheatley } from "../wheatley.js";
@@ -23,7 +22,7 @@ export default class RoleManager extends BotComponent {
     override async on_ready() {
         this.pink_role = unwrap(await this.wheatley.TCCPP.roles.fetch(this.wheatley.roles.pink.id));
         this.interval = set_interval(() => {
-            this.check_users().catch(critical_error);
+            this.check_users().catch(this.wheatley.critical_error.bind(this.wheatley));
         }, 30 * MINUTE);
     }
 
@@ -55,7 +54,7 @@ export default class RoleManager extends BotComponent {
                 }
             });
         } catch (e) {
-            critical_error(e);
+            this.wheatley.critical_error(e);
         }
     }
 }

--- a/src/components/roulette.ts
+++ b/src/components/roulette.ts
@@ -1,6 +1,5 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { SelfClearingMap, SelfClearingSet } from "../utils/containers.js";
 import { M } from "../utils/debugging-and-logging.js";
 import { colors, MINUTE } from "../common.js";
@@ -103,7 +102,7 @@ export default class Roulette extends BotComponent {
                         await (await command.get_member()).timeout(30 * MINUTE, "Bang");
                     }
                 } catch (error) {
-                    critical_error(
+                    this.wheatley.critical_error(
                         `promise failed for timeout of roulette loser ${[command.user.id, command.user.tag]}`,
                     );
                     M.error(error);

--- a/src/components/server-suggestion-reactions.ts
+++ b/src/components/server-suggestion-reactions.ts
@@ -3,7 +3,6 @@ import { strict as assert } from "assert";
 import { MINUTE } from "../common.js";
 import { delay } from "../utils/misc.js";
 import { file_exists } from "../utils/filesystem.js";
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { M } from "../utils/debugging-and-logging.js";
 import { BotComponent } from "../bot-component.js";
 import { SERVER_SUGGESTION_TRACKER_START_TIME, Wheatley } from "../wheatley.js";
@@ -137,7 +136,7 @@ export default class ServerSuggestionReactions extends BotComponent {
                         time: reaction.message.createdAt,
                         user: [user.tag, user.id],
                     });
-                    reaction.users.remove(user.id).catch(critical_error);
+                    reaction.users.remove(user.id).catch(this.wheatley.critical_error.bind(this.wheatley));
                 }, 5 * MINUTE);
             } else if (root_only_reacts.has(reaction.emoji.name!)) {
                 if (!this.wheatley.is_root(user)) {
@@ -147,7 +146,7 @@ export default class ServerSuggestionReactions extends BotComponent {
                         time: reaction.message.createdAt,
                         user: [user.tag, user.id],
                     });
-                    reaction.users.remove(user.id).catch(critical_error);
+                    reaction.users.remove(user.id).catch(this.wheatley.critical_error.bind(this.wheatley));
                 }
             }
         }

--- a/src/components/server-suggestion-tracker.ts
+++ b/src/components/server-suggestion-tracker.ts
@@ -3,7 +3,6 @@ import { strict as assert } from "assert";
 import { unwrap } from "../utils/misc.js";
 import { xxh3 } from "../utils/strings.js";
 import { api_wrap, departialize, forge_snowflake } from "../utils/discord.js";
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { KeyedMutexSet, SelfClearingSet } from "../utils/containers.js";
 import { M } from "../utils/debugging-and-logging.js";
 import { MINUTE } from "../common.js";
@@ -217,7 +216,7 @@ export default class ServerSuggestionTracker extends BotComponent {
                 }
             }
         } catch (e) {
-            critical_error(e);
+            this.wheatley.critical_error(e);
         }
     }
 
@@ -232,7 +231,7 @@ export default class ServerSuggestionTracker extends BotComponent {
             await status_message.delete();
             await this.wheatley.database.server_suggestions.deleteOne({ suggestion: message_id });
         } catch (e) {
-            critical_error(e);
+            this.wheatley.critical_error(e);
         }
     }
 
@@ -279,7 +278,7 @@ export default class ServerSuggestionTracker extends BotComponent {
             }
             return false;
         } catch (e) {
-            critical_error(e);
+            this.wheatley.critical_error(e);
         }
     }
 
@@ -306,7 +305,7 @@ export default class ServerSuggestionTracker extends BotComponent {
                 // already resolved
             }
         } catch (e) {
-            critical_error(e);
+            this.wheatley.critical_error(e);
         }
     }
 
@@ -331,7 +330,7 @@ export default class ServerSuggestionTracker extends BotComponent {
                 await this.handle_suggestion_channel_message(message);
             }
         } catch (e) {
-            critical_error(e);
+            this.wheatley.critical_error(e);
         }
     }
 
@@ -379,7 +378,7 @@ export default class ServerSuggestionTracker extends BotComponent {
                 M.log("Wheatley message deleted", message);
             }
         } catch (e) {
-            critical_error(e);
+            this.wheatley.critical_error(e);
         }
     }
 
@@ -401,7 +400,7 @@ export default class ServerSuggestionTracker extends BotComponent {
                 this.mutex.unlock(new_message.id);
             }
         } catch (e) {
-            critical_error(e);
+            this.wheatley.critical_error(e);
         }
     }
 
@@ -529,7 +528,7 @@ export default class ServerSuggestionTracker extends BotComponent {
                 }
             }
         } catch (e) {
-            critical_error(e);
+            this.wheatley.critical_error(e);
             try {
                 if (this.wheatley.is_root(user)) {
                     // only send diagnostics to root
@@ -537,7 +536,7 @@ export default class ServerSuggestionTracker extends BotComponent {
                     await member.send("Error while resolving suggestion");
                 }
             } catch (e) {
-                critical_error(e);
+                this.wheatley.critical_error(e);
             }
         }
     }
@@ -569,7 +568,7 @@ export default class ServerSuggestionTracker extends BotComponent {
                 }
             }
         } catch (e) {
-            critical_error(e);
+            this.wheatley.critical_error(e);
         }
     }
 
@@ -685,7 +684,7 @@ export default class ServerSuggestionTracker extends BotComponent {
                 }
             }
         } catch (e) {
-            critical_error(e);
+            this.wheatley.critical_error(e);
         }
         M.debug("server_suggestion tracker finished checking this.wheatley.database entries");
     }

--- a/src/components/shortcuts.ts
+++ b/src/components/shortcuts.ts
@@ -2,7 +2,7 @@ import * as Discord from "discord.js";
 
 import { strict as assert } from "assert";
 
-import { M, ignorable_error } from "../utils/debugging-and-logging.js";
+import { M } from "../utils/debugging-and-logging.js";
 import { colors } from "../common.js";
 import { BotComponent } from "../bot-component.js";
 import { Wheatley, create_error_reply } from "../wheatley.js";

--- a/src/components/speedrun.ts
+++ b/src/components/speedrun.ts
@@ -1,7 +1,6 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
 import { time_to_human } from "../utils/strings.js";
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { M } from "../utils/debugging-and-logging.js";
 import { colors } from "../common.js";
 import { BotComponent } from "../bot-component.js";
@@ -53,6 +52,8 @@ export default class Speedrun extends BotComponent {
                 text: `ID: ${user.id}`,
             })
             .setTimestamp();
-        this.wheatley.channels.staff_action_log.send({ embeds: [embed] }).catch(critical_error);
+        this.wheatley.channels.staff_action_log
+            .send({ embeds: [embed] })
+            .catch(this.wheatley.critical_error.bind(this.wheatley));
     }
 }

--- a/src/components/starboard.ts
+++ b/src/components/starboard.ts
@@ -4,7 +4,6 @@ import * as mongo from "mongodb";
 import { strict as assert } from "assert";
 import { unwrap } from "../utils/misc.js";
 import { EMOJIREGEX, departialize } from "../utils/discord.js";
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { KeyedMutexSet } from "../utils/containers.js";
 import { M } from "../utils/debugging-and-logging.js";
 import { DAY, MINUTE } from "../common.js";
@@ -259,7 +258,7 @@ export default class Starboard extends BotComponent {
                     });
                 } catch (e) {
                     // M.log("--------------->", message.url);
-                    critical_error(e);
+                    this.wheatley.critical_error(e);
                 }
             }
         } finally {
@@ -330,7 +329,7 @@ export default class Starboard extends BotComponent {
             } else {
                 do_delete = false;
                 M.log("--------------->", message.url);
-                critical_error(e);
+                this.wheatley.critical_error(e);
             }
         } finally {
             this.wheatley.database.unlock();

--- a/src/components/the-button.ts
+++ b/src/components/the-button.ts
@@ -2,7 +2,6 @@ import * as Discord from "discord.js";
 import { strict as assert } from "assert";
 import { floor, round, unwrap } from "../utils/misc.js";
 import { time_to_human } from "../utils/strings.js";
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { M } from "../utils/debugging-and-logging.js";
 import { DAY, MINUTE, colors } from "../common.js";
 import { BotComponent } from "../bot-component.js";
@@ -131,7 +130,7 @@ export default class TheButton extends BotComponent {
                 }
                 waiting = true;
                 this.update_message()
-                    .catch(critical_error)
+                    .catch(this.wheatley.critical_error.bind(this.wheatley))
                     .finally(() => (waiting = false));
             }
         }, 1000);

--- a/src/components/username-manager.ts
+++ b/src/components/username-manager.ts
@@ -1,6 +1,5 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { M } from "../utils/debugging-and-logging.js";
 import { BotComponent } from "../bot-component.js";
 import { Wheatley } from "../wheatley.js";
@@ -57,7 +56,7 @@ export default class UsernameManager extends BotComponent {
         await this.cleanup();
         // Every hour give it a scan
         this.interval = set_interval(() => {
-            this.cleanup().catch(critical_error);
+            this.cleanup().catch(this.wheatley.critical_error.bind(this.wheatley));
         }, 60 * MINUTE);
     }
 

--- a/src/infra/guild-command-manager.ts
+++ b/src/infra/guild-command-manager.ts
@@ -3,7 +3,6 @@ import * as Discord from "discord.js";
 
 import * as util from "util";
 
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { M } from "../utils/debugging-and-logging.js";
 import { Wheatley } from "../wheatley.js";
 
@@ -30,7 +29,7 @@ export class GuildCommandManager {
             M.log("Finished sending commands");
         } catch (e) {
             M.log(util.inspect({ body: this.commands }, { showHidden: false, depth: null, colors: true }));
-            critical_error(e);
+            this.wheatley.critical_error(e);
         }
     }
 }

--- a/src/infra/member-tracker.ts
+++ b/src/infra/member-tracker.ts
@@ -1,6 +1,5 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
-import { critical_error } from "../utils/debugging-and-logging.js";
 import { M } from "../utils/debugging-and-logging.js";
 import { MINUTE } from "../common.js";
 import { Wheatley } from "../wheatley.js";
@@ -121,7 +120,7 @@ export class MemberTracker {
                 try {
                     on_join(member, now);
                 } catch (e) {
-                    critical_error(e);
+                    this.wheatley.critical_error(e);
                 }
             }
         }
@@ -141,7 +140,7 @@ export class MemberTracker {
                 try {
                     on_ban(ban, now);
                 } catch (e) {
-                    critical_error(e);
+                    this.wheatley.critical_error(e);
                 }
             }
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,13 +19,10 @@
 import * as Discord from "discord.js";
 import * as Sentry from "@sentry/node";
 
-import { critical_error, init_debugger } from "./utils/debugging-and-logging.js";
 import { M } from "./utils/debugging-and-logging.js";
 
 import { wheatley_auth, Wheatley } from "./wheatley.js";
 import fs from "fs";
-
-let wheatley: Wheatley;
 
 async function main() {
     // Setup client
@@ -72,10 +69,6 @@ async function main() {
         M.log(`Logged in as ${client.user!.tag}`);
     });
 
-    M.debug("Setting up services");
-
-    init_debugger(client);
-
     M.debug("Setting up modules");
 
     // reading sync is okay here, we can't do anything in parallel anyway
@@ -88,15 +81,15 @@ async function main() {
     }
 
     try {
-        wheatley = new Wheatley(client, auth);
+        new Wheatley(client, auth);
     } catch (e) {
-        critical_error(e);
+        M.error(e);
     }
 }
 
 (async () => {
     return main();
-})().catch(critical_error);
+})().catch(M.error);
 
 process.on("uncaughtException", error => {
     M.error("uncaughtException", error);
@@ -105,5 +98,5 @@ process.on("uncaughtException", error => {
 
 // Last line of defense
 process.on("unhandledRejection", (reason, promise) => {
-    critical_error(`unhandledRejection ${reason} ${promise}`);
+    M.error(`unhandledRejection ${reason} ${promise}`);
 });

--- a/src/utils/debugging-and-logging.ts
+++ b/src/utils/debugging-and-logging.ts
@@ -1,10 +1,5 @@
 import moment from "moment";
 import chalk from "chalk";
-import * as Discord from "discord.js";
-import * as Sentry from "@sentry/node";
-import { zelis_id } from "../wheatley.js";
-import { to_string } from "./strings.js";
-import { send_long_message } from "./discord.js";
 
 function get_caller_location() {
     // https://stackoverflow.com/a/53339452/15675011
@@ -23,91 +18,24 @@ export class M {
         return moment().format("MM.DD.YY HH:mm:ss");
     }
     static log(...args: any[]) {
-        process.stdout.write(`[${M.get_timestamp()}] [log]   `);
+        process.stdout.write(`   [${M.get_timestamp()}] [log]   `);
         console.log(...args, `(from: ${get_caller_location()})`);
     }
     static debug(...args: any[]) {
-        process.stdout.write(`${chalk.gray(`[${M.get_timestamp()}] [debug]`)} `);
+        process.stdout.write(`${chalk.gray(`🛠️ [${M.get_timestamp()}] [debug]`)} `);
         console.log(...args, `(from: ${get_caller_location()})`);
     }
     static info(...args: any[]) {
-        process.stdout.write(`${chalk.blueBright(`[${M.get_timestamp()}] [info] `)} `);
+        process.stdout.write(`${chalk.blueBright(`ℹ️ [${M.get_timestamp()}] [info] `)} `);
         console.log(...args, `(from: ${get_caller_location()})`);
     }
     static warn(...args: any[]) {
-        process.stdout.write(`${chalk.yellowBright(`[${M.get_timestamp()}] [warn] `)} `);
+        process.stdout.write(`${chalk.yellowBright(`⚠️ [${M.get_timestamp()}] [warn] `)} `);
         console.log(...args, `(from: ${get_caller_location()})`);
     }
     static error(...args: any[]) {
-        process.stdout.write(`${chalk.redBright(`[${M.get_timestamp()}] [error]`)} `);
+        process.stdout.write(`${chalk.redBright(`🛑 [${M.get_timestamp()}] [error]`)} `);
         console.log(...args);
         console.trace();
     }
-}
-
-// FIXME: eliminate this hackery
-export let client: Discord.Client;
-let zelis: Discord.User | undefined | null;
-let has_tried_fetch_zelis = false;
-
-async function get_zelis() {
-    if (!has_tried_fetch_zelis) {
-        zelis = await client.users.fetch(zelis_id);
-        has_tried_fetch_zelis = true;
-    }
-    return zelis !== undefined && zelis !== null;
-}
-
-export function init_debugger(_client: Discord.Client) {
-    client = _client;
-}
-
-export function critical_error(arg: any) {
-    M.error(arg);
-    get_zelis()
-        .then(zelis_found => {
-            if (zelis_found) {
-                send_long_message(zelis!.dmChannel!, `Critical error occurred: ${to_string(arg)}`).catch(() => void 0);
-            }
-        })
-        .catch(() => void 0)
-        .finally(() => {
-            if (arg instanceof Error) {
-                Sentry.captureException(arg);
-            } else {
-                Sentry.captureMessage(to_string(arg));
-            }
-        });
-}
-
-export function ignorable_error(arg: any) {
-    M.error(arg);
-    get_zelis()
-        .then(zelis_found => {
-            if (zelis_found) {
-                zelis!.send(`Ignorable error occurred: ${to_string(arg)}`).catch(() => void 0);
-            }
-        })
-        .catch(() => void 0)
-        .finally(() => {
-            if (arg instanceof Error) {
-                Sentry.captureException(arg);
-            } else {
-                Sentry.captureMessage(to_string(arg));
-            }
-        });
-}
-
-export function milestone(message: string) {
-    M.info(message);
-    get_zelis()
-        .then(zelis_found => {
-            if (zelis_found) {
-                zelis!.send(message).catch(() => void 0);
-            }
-        })
-        .catch(() => void 0)
-        .finally(() => {
-            Sentry.captureMessage(message);
-        });
 }

--- a/src/utils/discord.ts
+++ b/src/utils/discord.ts
@@ -1,6 +1,5 @@
 import { strict as assert } from "assert";
 import * as Discord from "discord.js";
-import { client } from "./debugging-and-logging.js";
 import { unwrap } from "./misc.js";
 import { TextBasedCommand } from "../command-abstractions/text-based-command.js";
 import { is_string } from "./strings.js";
@@ -36,27 +35,6 @@ export function get_url_for(channel: Discord.GuildChannel | Discord.TextChannel 
 export function textchannelify(x: Discord.Channel): Discord.TextBasedChannel {
     assert(x.isTextBased());
     return x;
-}
-
-export async function fetch_text_channel(id: string) {
-    // TODO: Using the client from init_debugger is very ugly.
-    const channel = await client.channels.fetch(id);
-    assert(channel && channel instanceof Discord.TextChannel);
-    return channel;
-}
-
-export async function fetch_forum_channel(id: string) {
-    // TODO: Using the client from init_debugger is very ugly.
-    const channel = await client.channels.fetch(id);
-    assert(channel && channel instanceof Discord.ForumChannel);
-    return channel;
-}
-
-export async function fetch_thread_channel(channel: Discord.TextChannel, id: string) {
-    // TODO: Using the client from init_debugger is very ugly.
-    const thread = await channel.threads.fetch(id);
-    assert(thread && thread instanceof Discord.ThreadChannel);
-    return thread;
 }
 
 export function get_tag(channel: Discord.ForumChannel, name: string) {
@@ -132,7 +110,10 @@ export function is_media_link_embed(embed: Discord.APIEmbed | Discord.Embed) {
     return embed.image || embed.video || embed.thumbnail;
 }
 
-export async function send_long_message(channel: Discord.TextChannel | Discord.DMChannel, msg: string) {
+export async function send_long_message(
+    channel: Discord.TextChannel | Discord.ThreadChannel | Discord.DMChannel,
+    msg: string,
+) {
     if (msg.length > 2000) {
         const lines = msg.split("\n");
         let partial = "";


### PR DESCRIPTION
These changes move the `critical_error()`, `ignorable_error()`, and `milestone()` functions into the `Wheatley` object and use a log thread channel to output alerts instead of sending DMs to Zelis. This also eliminates the global `client` and `zelis` hackery.

Some places had hardcoded DMs to Zelis; this was replaced with a generic `alert()` function that also logs to the log thread.

The goal here is to take a first step towards decoupling Wheatley at least a little bit from TCCPP-specifics, and make it at least a tiny bit easier to run independent instances of the bot.

One notable change is that failures in `main.ts` are now only logged to the normal stdout log since these happen prior to a `Wheatley` object having been created. It is arguably not really necessary to get a discord notification whenever the bot failed to start; whoever started the bot should notice right away anyways, so this should be alright?