### PR TITLE
feat: whitelist our own invite

### DIFF
--- a/src/components/anti-invite-links.ts
+++ b/src/components/anti-invite-links.ts
@@ -9,6 +9,7 @@ const INVITE_RE =
     /(?:(?:discord(?:app)?|disboard)\.(?:gg|(?:com|org|me)\/(?:invite|server\/join))|(?<!\w)\.gg)\/(\S+)/i;
 
 const whitelist = [
+    "tccpp",
     "python",
     "csharp",
     "bVTPVpYVcv", // cuda


### PR DESCRIPTION
Users should be able to send invites to tccpp when in tccpp otherwise are we really in the tccpp discord???