### PR TITLE
Fix code masked links

### DIFF
--- a/src/components/wiki.ts
+++ b/src/components/wiki.ts
@@ -216,8 +216,8 @@ class ArticleParser {
     }
 
     /**
-     * Substitutes placeholders such as <br> or reference-style links in the
-     * string, but only outside inline code.
+     * Substitutes placeholders such as `<br>` or reference-style links in the
+     * string, but only placeholders outside inline code.
      * @param line the line, possibly containing backticks for inline code
      */
     private substitute_placeholders(line: string): string {
@@ -226,6 +226,8 @@ class ArticleParser {
         }
         let result = "";
         let piece = "";
+        // NOTE: This code makes the assumption that inline code never spans more than one line.
+        //       Discord allows that, but our articles never use it, and it simplifies parsing.
         let in_inline_code = false;
         let prev = "";
         for (const c of line) {

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,5 +1,6 @@
 import * as Discord from "discord.js";
 import XXH from "xxhashjs";
+import { strict as assert } from "assert";
 import { DAY, HOUR, MINUTE, MONTH, YEAR } from "../common.js";
 import { round, unwrap } from "./misc.js";
 import { remove } from "./arrays.js";
@@ -136,4 +137,29 @@ export function debug_unicode(str: string) {
 
 export function truncate(str: string, length: number) {
     return str.length <= length ? str : str.slice(0, length - 3) + "...";
+}
+
+/**
+ * Searches for a `c` character in `str` and returns its index,
+ * but respects backslash (`\`) escape characters.
+ * For example, when searching for `"` in `\""`, the result is the index of the second `"`.
+ * @param str the string to search in
+ * @param c the single-character string to search for
+ * @param start the start index, or `0` by default
+ * @return the index of the first unescaped occurrence of `c`, or `null` if none could be found
+ */
+export function index_of_first_unescaped(str: string, c: string, start: number = 0) {
+    assert(c.length === 1, "terminator must be single character");
+    let after_escape = false;
+
+    for (let i = start; i < str.length; i++) {
+        if (after_escape) {
+            after_escape = false;
+        } else if (str[i] === "\\") {
+            after_escape = true;
+        } else if (str[i] === c) {
+            return i;
+        }
+    }
+    return null;
 }


### PR DESCRIPTION
Prerequisite for: https://github.com/TCCPP/wiki-articles/issues/17

In essence, this PR makes the `ArticleParser` fully aware of masked link syntax. This is absolutely necessary to have reference-style masked links around code blocks. The current approach is to simply partition a line like
```md
[`mask`][ref]
```
... into pieces, separated by backticks for inline code. This is broken because the last part of the line is `][ref]`, which is not recognized as a masked link.

Additionally, this PR makes it possible to add "self-contained reference-stye links", i.e. `[mask]`, which is equivalent to `[mask][mask]`.