### PR TITLE
Make `PermissionManager` not freestanding

### DIFF
--- a/src/components/permissions-manager.ts
+++ b/src/components/permissions-manager.ts
@@ -26,10 +26,6 @@ type channel_permission_entry = {
 };
 
 export default class PermissionManager extends BotComponent {
-    static override get is_freestanding() {
-        return false;
-    }
-
     category_permissions: Record<string, category_permission_entry> = {};
     channel_overrides: Record<string, channel_permission_entry> = {};
 

--- a/src/components/permissions-manager.ts
+++ b/src/components/permissions-manager.ts
@@ -27,7 +27,7 @@ type channel_permission_entry = {
 
 export default class PermissionManager extends BotComponent {
     static override get is_freestanding() {
-        return true;
+        return false;
     }
 
     category_permissions: Record<string, category_permission_entry> = {};


### PR DESCRIPTION
Closes #112.

`PermissionManager` relies on TCCPP. In freestanding, you get a `TypeError` when it accesses `this.wheatley.roles.muted.id`.