### PR TITLE
Fix issue with podman not working on windows wsl

### DIFF
--- a/dev-container/Dockerfile
+++ b/dev-container/Dockerfile
@@ -30,7 +30,7 @@ RUN mkdir /opt/wheatley/ && chown wheatley:wheatley /opt/wheatley/
 RUN mkdir /opt/mongo/ && mkdir /opt/mongo/data && chown -R wheatley:wheatley /opt/mongo/
 USER wheatley
 
-COPY dev-container/entry.sh /entry.sh
+COPY --chmod=755 dev-container/entry.sh /entry.sh
 
 WORKDIR /opt/wheatley
 COPY --chown=wheatley:wheatley . .

--- a/dev-container/entry.sh
+++ b/dev-container/entry.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 /usr/bin/mongod -f /etc/mongod.conf --logpath /opt/mongo/mongod.log --dbpath /opt/mongo/data &
 


### PR DESCRIPTION
We discussed this a few weeks back and I had found the solution back then, but actually never got around to sending in a PR for the issue.

Here is the patch that allows podman to actually work using windows wsl. I've not yet tested this code on linux so will need ci to double check there is no regression on the linux end.