### PR TITLE
Revert passive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,16 +73,13 @@ Secrets and other bot info must be configured in the `auth.json` file. An exampl
     "host": "127.0.0.1", // optional
     "port": 27017 // optional
   },
-  "freestanding": false, // optional
-  "passive": false // optional
+  "freestanding": false // optional
 }
 ```
 
 Mongo credentials can be omitted locally if you don't need to work on components that use mongo. `freestanding: true`
 can be specified to turn on only components which don't rely on channels etc. specific to Together C & C++ to exist.
-Freestanding mode also disables connecting to MongoDB. `passive: true` can be specified to run the bot in passive mode,
-where it will not advertise or react to commands, and only load components that are marked as passive (useful for
-testing new features in a second instance without interfering with a running primary instance).
+Freestanding mode also disables connecting to MongoDB.
 
 ## Bot Component Abstraction
 
@@ -91,9 +88,6 @@ The bot is built of modular components. The BotComponent base class defines the 
 ```ts
 export class BotComponent {
   static get is_freestanding() {
-    return false;
-  }
-  static get is_passive() {
     return false;
   }
   // Add a command

--- a/src/bot-component.ts
+++ b/src/bot-component.ts
@@ -17,10 +17,6 @@ export class BotComponent {
         return false;
     }
 
-    static get is_passive() {
-        return false;
-    }
-
     protected readonly utilities: BotUtilities;
 
     constructor(protected readonly wheatley: Wheatley) {

--- a/src/command-manager.ts
+++ b/src/command-manager.ts
@@ -107,9 +107,6 @@ export class CommandManager {
             | ModalInteractionBuilder<true>
             | ButtonInteractionBuilder<true>,
     ) {
-        if (this.wheatley.passive) {
-            return;
-        }
         if (command instanceof TextBasedCommandBuilder) {
             for (const descriptor of command.to_command_descriptors(this.wheatley)) {
                 assert(!(descriptor.name in this.text_commands));
@@ -151,9 +148,6 @@ export class CommandManager {
 
     // returns false if the message was not a wheatley command
     private async handle_text_command(message: Discord.Message, prev_command_obj?: TextBasedCommand) {
-        if (this.wheatley.passive) {
-            return false;
-        }
         const match = message.content.match(CommandManager.command_regex);
         if (match) {
             const command_name = match[1];

--- a/src/wheatley.ts
+++ b/src/wheatley.ts
@@ -59,7 +59,6 @@ export type wheatley_auth = {
     guild?: string;
     token: string;
     freestanding?: boolean;
-    passive?: boolean;
     mongo?: wheatley_database_credentials;
     sentry?: string;
     virustotal?: string;
@@ -277,8 +276,6 @@ export class Wheatley {
     readonly guildId: string;
     // True if freestanding mode is enabled. Defaults to false.
     readonly freestanding: boolean;
-    // True if passive mode is enabled. Defaults to false.
-    readonly passive: boolean;
 
     // Some emojis
     readonly pepereally = "<:pepereally:643881257624666112>";
@@ -338,7 +335,6 @@ export class Wheatley {
     ) {
         this.id = auth.id;
         this.freestanding = auth.freestanding ?? false;
-        this.passive = auth.passive ?? false;
         this.guildId = auth.guild ?? TCCPP_ID;
 
         this.parameters = drop_token(auth);
@@ -501,12 +497,8 @@ export class Wheatley {
         await wrap(() => this.fetch_root_mod_list(this.client));
     }
 
-    async add_component<T extends BotComponent>(component: {
-        new (w: Wheatley): T;
-        get is_freestanding(): boolean;
-        get is_passive(): boolean;
-    }) {
-        if ((!this.passive || component.is_passive) && (!this.freestanding || component.is_freestanding)) {
+    async add_component<T extends BotComponent>(component: { new (w: Wheatley): T; get is_freestanding(): boolean }) {
+        if (!this.freestanding || component.is_freestanding) {
             M.log(`Initializing ${component.name}`);
             assert(!this.components.has(component.name), "Duplicate component name");
             const instance = new component(this);


### PR DESCRIPTION
Slash commands can be limited to specific users/roles/channels in server settings, making passive mode a very crude attempt at doing what can already be done in a much simpler and more precise way. Thus, passive mode is probably best removed again.