### PR TITLE
Introduce bot modules, move TCCPP-specific components into tccpp module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,3 @@
-# [submodule "src/modules/tccpp/private"]
-# 	path = src/modules/tccpp/private
-# 	url = git@github.com:TCCPP/wheatley-private.git
-
-# [submodule "dyno-import"]
-# 	path = dyno-import
-# 	url = git@github.com:TCCPP/dyno-import.git
-
 [submodule "wiki"]
 	path = wiki
 	url = git@github.com:TCCPP/wiki-articles.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
-[submodule "wheatley-private"]
-	path = src/wheatley-private
-	url = https://github.com/TCCPP/empty.git
-	# url = git@github.com:TCCPP/wheatley-private.git
+# [submodule "src/modules/tccpp/private"]
+# 	path = src/modules/tccpp/private
+# 	url = git@github.com:TCCPP/wheatley-private.git
 
 # [submodule "dyno-import"]
 # 	path = dyno-import
 # 	url = git@github.com:TCCPP/dyno-import.git
+
 [submodule "wiki"]
 	path = wiki
 	url = git@github.com:TCCPP/wiki-articles.git

--- a/README.md
+++ b/README.md
@@ -73,7 +73,13 @@ Secrets and other bot info must be configured in the `config.json` file. An exam
     "host": "127.0.0.1", // optional
     "port": 27017 // optional
   },
-  "freestanding": false // optional
+  "freestanding": false, // optional,
+  "exclude": [
+    // optional
+    "components/the-button.js",
+    "modules/tccpp/components/buzzwords.js",
+    "modules/tccpp/private/**"
+  ]
 }
 ```
 

--- a/config.default.json
+++ b/config.default.json
@@ -8,5 +8,10 @@
         "host": "127.0.0.1",
         "port": 27017
     },
-    "freestanding": true
+    "freestanding": true,
+    "exclude": [
+        "modules/tccpp/components/anti-self-star.js",
+        "modules/tccpp/components/buzzwords.js",
+        "modules/tccpp/private/**"
+    ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
                 "discord.js": "^14.17.2",
                 "dismark": "^0.1.1",
                 "express": "^4.21.2",
+                "glob": "^11.0.1",
                 "moment": "^2.30.1",
                 "mongodb": "^6.12.0",
                 "prom-client": "^15.1.3",
@@ -733,6 +734,75 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/nzakas"
+            }
+        },
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "license": "MIT"
+        },
+        "node_modules/@isaacs/cliui/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
@@ -2283,7 +2353,6 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
             "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-            "dev": true,
             "engines": {
                 "node": ">=12"
             },
@@ -2380,8 +2449,7 @@
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
         "node_modules/bintrees": {
             "version": "1.0.2",
@@ -2434,7 +2502,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
             "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
@@ -2663,7 +2730,6 @@
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-            "dev": true,
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -2948,6 +3014,12 @@
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
             }
+        },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "license": "MIT"
         },
         "node_modules/ee-first": {
             "version": "1.1.1",
@@ -3637,6 +3709,22 @@
                 "is-callable": "^1.1.3"
             }
         },
+        "node_modules/foreground-child": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.6",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/form-data": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -3755,6 +3843,29 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/glob": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
+            "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^4.0.1",
+                "minimatch": "^10.0.0",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^2.0.0"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/glob-parent": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3765,6 +3876,21 @@
             },
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/glob/node_modules/minimatch": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+            "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/globals": {
@@ -4292,8 +4418,22 @@
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "dev": true
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+        },
+        "node_modules/jackspeak": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
+            "integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/js-yaml": {
             "version": "4.1.0",
@@ -4527,6 +4667,15 @@
             "integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
             "dev": true
         },
+        "node_modules/lru-cache": {
+            "version": "11.0.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
+            "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+            "license": "ISC",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
         "node_modules/magic-bytes.js": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
@@ -4665,6 +4814,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/minipass": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
             }
         },
         "node_modules/module-details-from-path": {
@@ -4968,6 +5126,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+            "license": "BlueOak-1.0.0"
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5001,7 +5165,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5010,6 +5173,22 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+        },
+        "node_modules/path-scurry": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+            "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/path-to-regexp": {
             "version": "0.1.12",
@@ -5587,7 +5766,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-            "dev": true,
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -5599,7 +5777,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5636,7 +5813,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-            "dev": true,
             "engines": {
                 "node": ">=14"
             },
@@ -5754,11 +5930,61 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "license": "MIT"
+        },
+        "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/strip-ansi": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
             "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-            "dev": true,
             "dependencies": {
                 "ansi-regex": "^6.0.1"
             },
@@ -5767,6 +5993,28 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/strip-final-newline": {
@@ -6198,7 +6446,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -6299,6 +6546,74 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "license": "MIT"
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/wrap-ansi/node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "discord.js": "^14.17.2",
         "dismark": "^0.1.1",
         "express": "^4.21.2",
+        "glob": "^11.0.1",
         "moment": "^2.30.1",
         "mongodb": "^6.12.0",
         "prom-client": "^15.1.3",

--- a/src/modules/tccpp/components/anti-autoreact.ts
+++ b/src/modules/tccpp/components/anti-autoreact.ts
@@ -1,8 +1,8 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
-import { departialize } from "../utils/discord.js";
-import { M } from "../utils/debugging-and-logging.js";
-import { BotComponent } from "../bot-component.js";
+import { departialize } from "../../../utils/discord.js";
+import { M } from "../../../utils/debugging-and-logging.js";
+import { BotComponent } from "../../../bot-component.js";
 
 export default class AntiAutoreact extends BotComponent {
     obnoxious_autoreact_ids = new Set([

--- a/src/modules/tccpp/components/anti-forum-post-delete.ts
+++ b/src/modules/tccpp/components/anti-forum-post-delete.ts
@@ -2,10 +2,10 @@ import { strict as assert } from "assert";
 
 import * as Discord from "discord.js";
 
-import { get_tag } from "../utils/discord.js";
-import { M } from "../utils/debugging-and-logging.js";
-import { BotComponent } from "../bot-component.js";
-import { colors, MINUTE } from "../common.js";
+import { get_tag } from "../../../utils/discord.js";
+import { M } from "../../../utils/debugging-and-logging.js";
+import { BotComponent } from "../../../bot-component.js";
+import { colors, MINUTE } from "../../../common.js";
 
 function create_embed(title: string | undefined, color: number, msg: string) {
     const embed = new Discord.EmbedBuilder().setColor(color).setDescription(msg);

--- a/src/modules/tccpp/components/anti-screenshot.ts
+++ b/src/modules/tccpp/components/anti-screenshot.ts
@@ -2,11 +2,11 @@ import { strict as assert } from "assert";
 
 import * as Discord from "discord.js";
 
-import { delay } from "../utils/misc.js";
-import { M } from "../utils/debugging-and-logging.js";
-import { colors } from "../common.js";
-import { BotComponent } from "../bot-component.js";
-import { Wheatley } from "../wheatley.js";
+import { delay } from "../../../utils/misc.js";
+import { M } from "../../../utils/debugging-and-logging.js";
+import { colors } from "../../../common.js";
+import { BotComponent } from "../../../bot-component.js";
+import { Wheatley } from "../../../wheatley.js";
 
 const DISMISS_TIME = 30 * 1000;
 

--- a/src/modules/tccpp/components/anti-self-star.ts
+++ b/src/modules/tccpp/components/anti-self-star.ts
@@ -1,8 +1,8 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
-import { departialize } from "../utils/discord.js";
-import { BotComponent } from "../bot-component.js";
-import { Wheatley } from "../wheatley.js";
+import { departialize } from "../../../utils/discord.js";
+import { BotComponent } from "../../../bot-component.js";
+import { Wheatley } from "../../../wheatley.js";
 import { has_media } from "./autoreact.js";
 
 export default class AntiSelfStar extends BotComponent {

--- a/src/modules/tccpp/components/auto-reply.ts
+++ b/src/modules/tccpp/components/auto-reply.ts
@@ -2,10 +2,10 @@ import * as Discord from "discord.js";
 
 import { strict as assert } from "assert";
 
-import { M } from "../utils/debugging-and-logging.js";
-import { DAY, HOUR } from "../common.js";
-import { BotComponent } from "../bot-component.js";
-import { SelfClearingSet } from "../utils/containers.js";
+import { M } from "../../../utils/debugging-and-logging.js";
+import { DAY, HOUR } from "../../../common.js";
+import { BotComponent } from "../../../bot-component.js";
+import { SelfClearingSet } from "../../../utils/containers.js";
 
 const LLM_REGEX = /\b(?<!!)llms?\b/gi;
 

--- a/src/modules/tccpp/components/autoreact.ts
+++ b/src/modules/tccpp/components/autoreact.ts
@@ -1,13 +1,13 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
-import { delay } from "../utils/misc.js";
-import { is_media_link_embed } from "../utils/discord.js";
-import { M } from "../utils/debugging-and-logging.js";
-import { MINUTE, SECOND } from "../common.js";
-import { BotComponent } from "../bot-component.js";
-import { Wheatley } from "../wheatley.js";
-import { SelfClearingMap } from "../utils/containers.js";
-import { clear_timeout, set_timeout } from "../utils/node.js";
+import { delay } from "../../../utils/misc.js";
+import { is_media_link_embed } from "../../../utils/discord.js";
+import { M } from "../../../utils/debugging-and-logging.js";
+import { MINUTE, SECOND } from "../../../common.js";
+import { BotComponent } from "../../../bot-component.js";
+import { Wheatley } from "../../../wheatley.js";
+import { SelfClearingMap } from "../../../utils/containers.js";
+import { clear_timeout, set_timeout } from "../../../utils/node.js";
 
 export function has_media(message: Discord.Message | Discord.PartialMessage) {
     return (

--- a/src/modules/tccpp/components/buzzwords.ts
+++ b/src/modules/tccpp/components/buzzwords.ts
@@ -1,13 +1,13 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
-import { round, unwrap } from "../utils/misc.js";
-import { SelfClearingSet } from "../utils/containers.js";
-import { M } from "../utils/debugging-and-logging.js";
-import { MINUTE, colors } from "../common.js";
-import { BotComponent } from "../bot-component.js";
-import { Wheatley } from "../wheatley.js";
-import { buzzword_scoreboard_entry } from "../infra/schemata/buzzwords.js";
-import { set_interval } from "../utils/node.js";
+import { round, unwrap } from "../../../utils/misc.js";
+import { SelfClearingSet } from "../../../utils/containers.js";
+import { M } from "../../../utils/debugging-and-logging.js";
+import { MINUTE, colors } from "../../../common.js";
+import { BotComponent } from "../../../bot-component.js";
+import { Wheatley } from "../../../wheatley.js";
+import { buzzword_scoreboard_entry } from "../../../infra/schemata/buzzwords.js";
+import { set_interval } from "../../../utils/node.js";
 
 const ENABLED = false;
 

--- a/src/modules/tccpp/components/c-help-redirect.ts
+++ b/src/modules/tccpp/components/c-help-redirect.ts
@@ -1,13 +1,13 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
-import { BotComponent } from "../bot-component.js";
-import { CommandSetBuilder } from "../command-abstractions/command-set-builder.js";
-import { Wheatley } from "../wheatley.js";
-import { EarlyReplyMode, TextBasedCommandBuilder } from "../command-abstractions/text-based-command-builder.js";
-import { TextBasedCommand } from "../command-abstractions/text-based-command.js";
-import { HOUR, DAY } from "../common.js";
-import { M } from "../utils/debugging-and-logging.js";
-import { SelfClearingSet } from "../utils/containers.js";
+import { BotComponent } from "../../../bot-component.js";
+import { CommandSetBuilder } from "../../../command-abstractions/command-set-builder.js";
+import { Wheatley } from "../../../wheatley.js";
+import { EarlyReplyMode, TextBasedCommandBuilder } from "../../../command-abstractions/text-based-command-builder.js";
+import { TextBasedCommand } from "../../../command-abstractions/text-based-command.js";
+import { HOUR, DAY } from "../../../common.js";
+import { M } from "../../../utils/debugging-and-logging.js";
+import { SelfClearingSet } from "../../../utils/containers.js";
 
 const code_block_start = "```";
 

--- a/src/modules/tccpp/components/core-guidelines.ts
+++ b/src/modules/tccpp/components/core-guidelines.ts
@@ -2,16 +2,16 @@ import * as Discord from "discord.js";
 
 import * as fs from "fs";
 
-import { M } from "../utils/debugging-and-logging.js";
+import { M } from "../../../utils/debugging-and-logging.js";
 
-import { Index, IndexEntry } from "../algorithm/search.js";
-import { core_guidelines_entry, core_guidelines_index } from "../../indexes/core_guidelines/types.js";
-import { BotComponent } from "../bot-component.js";
-import { CommandSetBuilder } from "../command-abstractions/command-set-builder.js";
-import { Wheatley } from "../wheatley.js";
-import { colors } from "../common.js";
-import { EarlyReplyMode, TextBasedCommandBuilder } from "../command-abstractions/text-based-command-builder.js";
-import { TextBasedCommand } from "../command-abstractions/text-based-command.js";
+import { Index, IndexEntry } from "../../../algorithm/search.js";
+import { core_guidelines_entry, core_guidelines_index } from "../../../../indexes/core_guidelines/types.js";
+import { BotComponent } from "../../../bot-component.js";
+import { CommandSetBuilder } from "../../../command-abstractions/command-set-builder.js";
+import { Wheatley } from "../../../wheatley.js";
+import { colors } from "../../../common.js";
+import { EarlyReplyMode, TextBasedCommandBuilder } from "../../../command-abstractions/text-based-command-builder.js";
+import { TextBasedCommand } from "../../../command-abstractions/text-based-command.js";
 
 type augmented_core_guidelines_entry = core_guidelines_entry & IndexEntry;
 

--- a/src/modules/tccpp/components/cppref.ts
+++ b/src/modules/tccpp/components/cppref.ts
@@ -4,17 +4,17 @@ import { strict as assert } from "assert";
 
 import * as fs from "fs";
 
-import { format_list } from "../utils/strings.js";
-import { M } from "../utils/debugging-and-logging.js";
+import { format_list } from "../../../utils/strings.js";
+import { M } from "../../../utils/debugging-and-logging.js";
 
-import { cppref_index, cppref_page, CpprefSubIndex } from "../../indexes/cppref/types.js";
-import { Index } from "../algorithm/search.js";
-import { BotComponent } from "../bot-component.js";
-import { CommandSetBuilder } from "../command-abstractions/command-set-builder.js";
-import { Wheatley } from "../wheatley.js";
-import { colors } from "../common.js";
-import { EarlyReplyMode, TextBasedCommandBuilder } from "../command-abstractions/text-based-command-builder.js";
-import { TextBasedCommand } from "../command-abstractions/text-based-command.js";
+import { cppref_index, cppref_page, CpprefSubIndex } from "../../../../indexes/cppref/types.js";
+import { Index } from "../../../algorithm/search.js";
+import { BotComponent } from "../../../bot-component.js";
+import { CommandSetBuilder } from "../../../command-abstractions/command-set-builder.js";
+import { Wheatley } from "../../../wheatley.js";
+import { colors } from "../../../common.js";
+import { EarlyReplyMode, TextBasedCommandBuilder } from "../../../command-abstractions/text-based-command-builder.js";
+import { TextBasedCommand } from "../../../command-abstractions/text-based-command.js";
 
 function eliminate_aliases_and_duplicates(pages: cppref_page[]) {
     // There's this annoying thing where multiple pages are really the same page

--- a/src/modules/tccpp/components/days-since-last-incident.ts
+++ b/src/modules/tccpp/components/days-since-last-incident.ts
@@ -2,13 +2,13 @@ import * as Discord from "discord.js";
 
 import { strict as assert } from "assert";
 
-import { BotComponent } from "../bot-component.js";
-import { Wheatley } from "../wheatley.js";
-import { unwrap } from "../utils/misc.js";
-import { build_description, capitalize, time_to_human } from "../utils/strings.js";
-import { MINUTE } from "../common.js";
-import { moderation_entry } from "../infra/schemata/moderation.js";
-import { set_interval } from "../utils/node.js";
+import { BotComponent } from "../../../bot-component.js";
+import { Wheatley } from "../../../wheatley.js";
+import { unwrap } from "../../../utils/misc.js";
+import { build_description, capitalize, time_to_human } from "../../../utils/strings.js";
+import { MINUTE } from "../../../common.js";
+import { moderation_entry } from "../../../infra/schemata/moderation.js";
+import { set_interval } from "../../../utils/node.js";
 
 type incident_info = { time: string; user: string; user_name: string; type: string };
 

--- a/src/modules/tccpp/components/formatting-error-detection.ts
+++ b/src/modules/tccpp/components/formatting-error-detection.ts
@@ -2,12 +2,12 @@ import * as Discord from "discord.js";
 
 import { strict as assert } from "assert";
 
-import { M } from "../utils/debugging-and-logging.js";
-import { colors, MINUTE } from "../common.js";
-import { BotComponent } from "../bot-component.js";
-import { build_description, parse_out } from "../utils/strings.js";
-import Code from "./code.js";
-import { SelfClearingMap, SelfClearingSet } from "../utils/containers.js";
+import { M } from "../../../utils/debugging-and-logging.js";
+import { colors, MINUTE } from "../../../common.js";
+import { BotComponent } from "../../../bot-component.js";
+import { build_description, parse_out } from "../../../utils/strings.js";
+import Code from "../../../components/code.js";
+import { SelfClearingMap, SelfClearingSet } from "../../../utils/containers.js";
 import * as dismark from "dismark";
 
 const FAILED_CODE_BLOCK_RE = /^(?:"""?|'''?)(.+?)(?:"""?|'''?|$)/s;

--- a/src/modules/tccpp/components/forum-channels.ts
+++ b/src/modules/tccpp/components/forum-channels.ts
@@ -1,13 +1,13 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
-import { decode_snowflake, fetch_all_threads_archive_count, get_tag } from "../utils/discord.js";
-import { SelfClearingSet } from "../utils/containers.js";
-import { M } from "../utils/debugging-and-logging.js";
-import { colors, DAY, HOUR, MINUTE } from "../common.js";
-import { BotComponent } from "../bot-component.js";
-import { Wheatley } from "../wheatley.js";
-import { clear_timeout, set_interval, set_timeout } from "../utils/node.js";
-import { Synopsinator } from "../utils/synopsis.js";
+import { decode_snowflake, fetch_all_threads_archive_count, get_tag } from "../../../utils/discord.js";
+import { SelfClearingSet } from "../../../utils/containers.js";
+import { M } from "../../../utils/debugging-and-logging.js";
+import { colors, DAY, HOUR, MINUTE } from "../../../common.js";
+import { BotComponent } from "../../../bot-component.js";
+import { Wheatley } from "../../../wheatley.js";
+import { clear_timeout, set_interval, set_timeout } from "../../../utils/node.js";
+import { Synopsinator } from "../../../utils/synopsis.js";
 
 // TODO: Take into account thread's inactivity setting
 

--- a/src/modules/tccpp/components/forum-control.ts
+++ b/src/modules/tccpp/components/forum-control.ts
@@ -1,14 +1,14 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
-import { unwrap } from "../utils/misc.js";
-import { get_tag } from "../utils/discord.js";
-import { M } from "../utils/debugging-and-logging.js";
-import { colors } from "../common.js";
-import { BotComponent } from "../bot-component.js";
-import { CommandSetBuilder } from "../command-abstractions/command-set-builder.js";
-import { Wheatley } from "../wheatley.js";
-import { EarlyReplyMode, TextBasedCommandBuilder } from "../command-abstractions/text-based-command-builder.js";
-import { TextBasedCommand } from "../command-abstractions/text-based-command.js";
+import { unwrap } from "../../../utils/misc.js";
+import { get_tag } from "../../../utils/discord.js";
+import { M } from "../../../utils/debugging-and-logging.js";
+import { colors } from "../../../common.js";
+import { BotComponent } from "../../../bot-component.js";
+import { CommandSetBuilder } from "../../../command-abstractions/command-set-builder.js";
+import { Wheatley } from "../../../wheatley.js";
+import { EarlyReplyMode, TextBasedCommandBuilder } from "../../../command-abstractions/text-based-command-builder.js";
+import { TextBasedCommand } from "../../../command-abstractions/text-based-command.js";
 
 /*
  * Forum thread handling:

--- a/src/modules/tccpp/components/insult.ts
+++ b/src/modules/tccpp/components/insult.ts
@@ -2,7 +2,7 @@ import * as Discord from "discord.js";
 
 import { strict as assert } from "assert";
 
-import { BotComponent } from "../bot-component.js";
+import { BotComponent } from "../../../bot-component.js";
 
 export default class Insult extends BotComponent {
     static override get is_freestanding() {

--- a/src/modules/tccpp/components/man7.ts
+++ b/src/modules/tccpp/components/man7.ts
@@ -4,16 +4,16 @@ import { strict as assert } from "assert";
 
 import * as fs from "fs";
 
-import { M } from "../utils/debugging-and-logging.js";
+import { M } from "../../../utils/debugging-and-logging.js";
 
-import { Index, IndexEntry } from "../algorithm/search.js";
-import { man7_entry, man7_index } from "../../indexes/man7/types.js";
-import { BotComponent } from "../bot-component.js";
-import { CommandSetBuilder } from "../command-abstractions/command-set-builder.js";
-import { Wheatley } from "../wheatley.js";
-import { colors } from "../common.js";
-import { EarlyReplyMode, TextBasedCommandBuilder } from "../command-abstractions/text-based-command-builder.js";
-import { TextBasedCommand } from "../command-abstractions/text-based-command.js";
+import { Index, IndexEntry } from "../../../algorithm/search.js";
+import { man7_entry, man7_index } from "../../../../indexes/man7/types.js";
+import { BotComponent } from "../../../bot-component.js";
+import { CommandSetBuilder } from "../../../command-abstractions/command-set-builder.js";
+import { Wheatley } from "../../../wheatley.js";
+import { colors } from "../../../common.js";
+import { EarlyReplyMode, TextBasedCommandBuilder } from "../../../command-abstractions/text-based-command-builder.js";
+import { TextBasedCommand } from "../../../command-abstractions/text-based-command.js";
 
 type augmented_man7_entry = man7_entry & IndexEntry;
 

--- a/src/modules/tccpp/components/roulette.ts
+++ b/src/modules/tccpp/components/roulette.ts
@@ -1,14 +1,14 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
-import { SelfClearingMap, SelfClearingSet } from "../utils/containers.js";
-import { M } from "../utils/debugging-and-logging.js";
-import { colors, MINUTE } from "../common.js";
-import { BotComponent } from "../bot-component.js";
-import { CommandSetBuilder } from "../command-abstractions/command-set-builder.js";
-import { Wheatley } from "../wheatley.js";
-import { EarlyReplyMode, TextBasedCommandBuilder } from "../command-abstractions/text-based-command-builder.js";
-import { TextBasedCommand } from "../command-abstractions/text-based-command.js";
-import { roulette_leaderboard_entry } from "../infra/schemata/roulette.js";
+import { SelfClearingMap, SelfClearingSet } from "../../../utils/containers.js";
+import { M } from "../../../utils/debugging-and-logging.js";
+import { colors, MINUTE } from "../../../common.js";
+import { BotComponent } from "../../../bot-component.js";
+import { CommandSetBuilder } from "../../../command-abstractions/command-set-builder.js";
+import { Wheatley } from "../../../wheatley.js";
+import { EarlyReplyMode, TextBasedCommandBuilder } from "../../../command-abstractions/text-based-command-builder.js";
+import { TextBasedCommand } from "../../../command-abstractions/text-based-command.js";
+import { roulette_leaderboard_entry } from "../../../infra/schemata/roulette.js";
 
 const LEADERBOARD_ENTRIES = 20;
 

--- a/src/modules/tccpp/components/server-suggestion-reactions.ts
+++ b/src/modules/tccpp/components/server-suggestion-reactions.ts
@@ -1,13 +1,13 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
-import { MINUTE } from "../common.js";
-import { delay } from "../utils/misc.js";
-import { file_exists } from "../utils/filesystem.js";
-import { M } from "../utils/debugging-and-logging.js";
-import { BotComponent } from "../bot-component.js";
-import { SERVER_SUGGESTION_TRACKER_START_TIME, Wheatley } from "../wheatley.js";
-import { forge_snowflake } from "../utils/discord.js";
-import { set_timeout } from "../utils/node.js";
+import { MINUTE } from "../../../common.js";
+import { delay } from "../../../utils/misc.js";
+import { file_exists } from "../../../utils/filesystem.js";
+import { M } from "../../../utils/debugging-and-logging.js";
+import { BotComponent } from "../../../bot-component.js";
+import { SERVER_SUGGESTION_TRACKER_START_TIME, Wheatley } from "../../../wheatley.js";
+import { forge_snowflake } from "../../../utils/discord.js";
+import { set_timeout } from "../../../utils/node.js";
 
 let react_blacklist = new Set<string>();
 

--- a/src/modules/tccpp/components/server-suggestion-tracker.ts
+++ b/src/modules/tccpp/components/server-suggestion-tracker.ts
@@ -1,16 +1,16 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
-import { unwrap } from "../utils/misc.js";
-import { xxh3 } from "../utils/strings.js";
-import { api_wrap, departialize, forge_snowflake } from "../utils/discord.js";
-import { KeyedMutexSet, SelfClearingSet } from "../utils/containers.js";
-import { M } from "../utils/debugging-and-logging.js";
-import { MINUTE } from "../common.js";
-import { BotComponent } from "../bot-component.js";
-import { CommandSetBuilder } from "../command-abstractions/command-set-builder.js";
-import { Wheatley } from "../wheatley.js";
-import { EarlyReplyMode, TextBasedCommandBuilder } from "../command-abstractions/text-based-command-builder.js";
-import { TextBasedCommand } from "../command-abstractions/text-based-command.js";
+import { unwrap } from "../../../utils/misc.js";
+import { xxh3 } from "../../../utils/strings.js";
+import { api_wrap, departialize, forge_snowflake } from "../../../utils/discord.js";
+import { KeyedMutexSet, SelfClearingSet } from "../../../utils/containers.js";
+import { M } from "../../../utils/debugging-and-logging.js";
+import { MINUTE } from "../../../common.js";
+import { BotComponent } from "../../../bot-component.js";
+import { CommandSetBuilder } from "../../../command-abstractions/command-set-builder.js";
+import { Wheatley } from "../../../wheatley.js";
+import { EarlyReplyMode, TextBasedCommandBuilder } from "../../../command-abstractions/text-based-command-builder.js";
+import { TextBasedCommand } from "../../../command-abstractions/text-based-command.js";
 
 const resolution_reactions = ["🟢", "🔴", "🟡", "🚫"];
 const resolution_reactions_set = new Set(resolution_reactions);

--- a/src/modules/tccpp/components/skill-role-suggestion.ts
+++ b/src/modules/tccpp/components/skill-role-suggestion.ts
@@ -2,22 +2,22 @@ import * as Discord from "discord.js";
 
 import { strict as assert } from "assert";
 
-import { descending, unwrap } from "../utils/misc.js";
-import { departialize, get_tag } from "../utils/discord.js";
-import { SelfClearingMap } from "../utils/containers.js";
-import { M } from "../utils/debugging-and-logging.js";
-import { colors, DAY, MINUTE } from "../common.js";
-import { BotComponent } from "../bot-component.js";
-import { CommandSetBuilder } from "../command-abstractions/command-set-builder.js";
-import { skill_roles_order, Wheatley } from "../wheatley.js";
+import { descending, unwrap } from "../../../utils/misc.js";
+import { departialize, get_tag } from "../../../utils/discord.js";
+import { SelfClearingMap } from "../../../utils/containers.js";
+import { M } from "../../../utils/debugging-and-logging.js";
+import { colors, DAY, MINUTE } from "../../../common.js";
+import { BotComponent } from "../../../bot-component.js";
+import { CommandSetBuilder } from "../../../command-abstractions/command-set-builder.js";
+import { skill_roles_order, Wheatley } from "../../../wheatley.js";
 import {
     UserContextMenuInteractionBuilder,
     MessageContextMenuInteractionBuilder,
-} from "../command-abstractions/context-menu.js";
-import { build_description, capitalize } from "../utils/strings.js";
-import { skill_level, skill_suggestion_thread_entry } from "../infra/schemata/skill-role-suggestion.js";
-import { EarlyReplyMode, TextBasedCommandBuilder } from "../command-abstractions/text-based-command-builder.js";
-import { TextBasedCommand } from "../command-abstractions/text-based-command.js";
+} from "../../../command-abstractions/context-menu.js";
+import { build_description, capitalize } from "../../../utils/strings.js";
+import { skill_level, skill_suggestion_thread_entry } from "../../../infra/schemata/skill-role-suggestion.js";
+import { EarlyReplyMode, TextBasedCommandBuilder } from "../../../command-abstractions/text-based-command-builder.js";
+import { TextBasedCommand } from "../../../command-abstractions/text-based-command.js";
 
 type interaction_context = { member: Discord.GuildMember; role?: string; context?: Discord.Message };
 

--- a/src/modules/tccpp/components/status.ts
+++ b/src/modules/tccpp/components/status.ts
@@ -2,8 +2,8 @@ import * as Discord from "discord.js";
 
 import { strict as assert } from "assert";
 
-import { BotComponent } from "../bot-component.js";
-import { Wheatley } from "../wheatley.js";
+import { BotComponent } from "../../../bot-component.js";
+import { Wheatley } from "../../../wheatley.js";
 
 export default class Status extends BotComponent {
     override async on_ready() {

--- a/src/modules/tccpp/components/the-button.ts
+++ b/src/modules/tccpp/components/the-button.ts
@@ -1,14 +1,14 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
-import { floor, round, unwrap } from "../utils/misc.js";
-import { time_to_human } from "../utils/strings.js";
-import { M } from "../utils/debugging-and-logging.js";
-import { DAY, MINUTE, colors } from "../common.js";
-import { BotComponent } from "../bot-component.js";
-import { Wheatley } from "../wheatley.js";
-import { button_scoreboard_entry } from "../infra/schemata/the-button.js";
-import { set_interval } from "../utils/node.js";
-import { discord_timestamp } from "../utils/discord.js";
+import { floor, round, unwrap } from "../../../utils/misc.js";
+import { time_to_human } from "../../../utils/strings.js";
+import { M } from "../../../utils/debugging-and-logging.js";
+import { DAY, MINUTE, colors } from "../../../common.js";
+import { BotComponent } from "../../../bot-component.js";
+import { Wheatley } from "../../../wheatley.js";
+import { button_scoreboard_entry } from "../../../infra/schemata/the-button.js";
+import { set_interval } from "../../../utils/node.js";
+import { discord_timestamp } from "../../../utils/discord.js";
 
 function dissectDelta(delta: number) {
     let seconds = delta / 1000;

--- a/src/modules/tccpp/components/thread-based-channels.ts
+++ b/src/modules/tccpp/components/thread-based-channels.ts
@@ -1,10 +1,10 @@
 import * as Discord from "discord.js";
 import { strict as assert } from "assert";
-import { unwrap } from "../utils/misc.js";
-import { M } from "../utils/debugging-and-logging.js";
-import { colors } from "../common.js";
-import { BotComponent } from "../bot-component.js";
-import { Wheatley } from "../wheatley.js";
+import { unwrap } from "../../../utils/misc.js";
+import { M } from "../../../utils/debugging-and-logging.js";
+import { colors } from "../../../common.js";
+import { BotComponent } from "../../../bot-component.js";
+import { Wheatley } from "../../../wheatley.js";
 
 /*
  * Thread-based channel logic (non-forum)

--- a/src/utils/filesystem.ts
+++ b/src/utils/filesystem.ts
@@ -1,18 +1,6 @@
 import { strict as assert } from "assert";
 import * as fs from "fs";
 import { execFile, ExecFileOptions } from "child_process";
-import * as path from "path";
-
-export async function* walk_dir(dir: string): AsyncGenerator<string> {
-    for (const f of await fs.promises.readdir(dir)) {
-        const file_path = path.join(dir, f).replace(/\\/g, "/");
-        if ((await fs.promises.stat(file_path)).isDirectory()) {
-            yield* walk_dir(file_path);
-        } else {
-            yield file_path;
-        }
-    }
-}
 
 export async function directory_exists(path: string) {
     try {

--- a/src/wheatley.ts
+++ b/src/wheatley.ts
@@ -263,8 +263,6 @@ export class Wheatley {
 
     database: WheatleyDatabaseProxy;
 
-    link_blacklist: any;
-
     // whether wheatley is ready (client is ready + wheatley has set up)
     ready = false;
 
@@ -399,18 +397,6 @@ export class Wheatley {
             const default_export = (await import(`../${file.replace(".ts", ".js")}`)).default;
             if (default_export !== undefined) {
                 await this.add_component(default_export);
-            }
-        }
-
-        if (await directory_exists("src/wheatley-private/components")) {
-            for await (const file of walk_dir("src/wheatley-private/components")) {
-                const default_export = (await import(`../${file.replace(".ts", ".js")}`)).default;
-                if (default_export !== undefined) {
-                    const component = await this.add_component(default_export);
-                    if (file.endsWith("link-blacklist.ts")) {
-                        this.link_blacklist = component;
-                    }
-                }
             }
         }
 

--- a/test/cppref.ts
+++ b/test/cppref.ts
@@ -1,7 +1,7 @@
 import { assert, describe, expect, it } from "vitest";
 
 import { CpprefSubIndex } from "../indexes/cppref/types.js";
-import { CpprefIndex } from "../src/components/cppref.js";
+import { CpprefIndex } from "../src/modules/tccpp/components/cppref.js";
 
 type TestCase = {
     query: string | string[];

--- a/test/man7.ts
+++ b/test/man7.ts
@@ -1,6 +1,6 @@
 import { assert, describe, expect, it } from "vitest";
 
-import { Man7Index } from "../src/components/man7.js";
+import { Man7Index } from "../src/modules/tccpp/components/man7.js";
 
 type TestCase = {
     query: string | string[];

--- a/test/wiki-articles.ts
+++ b/test/wiki-articles.ts
@@ -1,30 +1,14 @@
 import { describe, test } from "vitest";
 
 import * as fs from "fs";
-import * as path from "path";
+import { globSync } from "glob";
 
-import { is_article, parse_article, wiki_dir } from "../src/components/wiki.js";
-
-function* walk_dir(dir: string): Generator<string> {
-    // todo: duplicate
-    for (const f of fs.readdirSync(dir)) {
-        const file_path = path.join(dir, f).replace(/\\/g, "/");
-        if (fs.statSync(file_path).isDirectory()) {
-            yield* walk_dir(file_path);
-        } else {
-            yield file_path;
-        }
-    }
-}
+import { parse_article } from "../src/components/wiki.js";
 
 describe("parse wiki articles", () => {
-    for (const file_path of walk_dir(wiki_dir)) {
-        if (!is_article(file_path)) {
-            continue;
-        }
-        const name = path.basename(file_path, path.extname(file_path));
-        test(`${name} article should parse`, async () => {
-            const content = await fs.promises.readFile(file_path, { encoding: "utf-8" });
+    for (const file_path of globSync("wiki/articles/**/*.md", { withFileTypes: true })) {
+        test(`${file_path.name} article should parse`, async () => {
+            const content = await fs.promises.readFile(file_path.fullpath(), { encoding: "utf-8" });
             parse_article(null, content, {
                 channels: {
                     resources: { id: null },


### PR DESCRIPTION
Take a first step in untying Wheatley from TCCPP by introducing bot modules and moving TCCPP stuff into a `tccpp` module. Also introduces an `excludes` config option to skip loading certain components, and replaces our custom `walk_dir()` with the `glob` package.