### PR TITLE
Simplify build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,6 @@
         "incremental": true,
         "skipLibCheck": true,
     },
-    "exclude": ["node_modules", "build", "indexes/", "dyno-logs", "indexes", "scripts"]
+    "include": ["./src/**/*"],
+    "exclude": []
 }


### PR DESCRIPTION
simplify and future-proof build by including only `src/` instead of excluding everything else.