### PR TITLE
Revert "Simplify build (#138)"

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,5 @@
         "incremental": true,
         "skipLibCheck": true,
     },
-    "include": ["./src/**/*"],
-    "exclude": []
+    "exclude": ["node_modules", "build", "indexes/", "dyno-logs", "indexes", "scripts"]
 }


### PR DESCRIPTION
This reverts commit 57140d7cbe406492d7b0436be012c53b21ce4e14, which broke the `lint-files` step.