### PR TITLE
Add back example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Secrets and other bot info must be configured in the `config.json` file. An exam
   "freestanding": false, // optional,
   "exclude": [
     // optional
+    "components/shortcuts.js",
     "modules/tccpp/components/april1/**"
   ]
 }


### PR DESCRIPTION
We should have an example to illustrate how to exclude specific components (it's important to use the .js extension).