### PR TITLE
Refactor emoji stuff

### DIFF
--- a/src/components/moderation/massban.ts
+++ b/src/components/moderation/massban.ts
@@ -23,7 +23,7 @@ export default class Massban extends BotComponent {
                 if (this.wheatley.is_authorized_mod(message.member)) {
                     await this.do_mass_ban(message);
                 } else {
-                    await message.reply(`Unauthorized ${this.wheatley.pepereally}`);
+                    await message.reply(`Unauthorized ${this.wheatley.emoji.access_denied}`);
                 }
             }
         } catch (e) {

--- a/src/components/moderation/moderation-common.ts
+++ b/src/components/moderation/moderation-common.ts
@@ -592,14 +592,14 @@ export abstract class ModerationComponent extends BotComponent {
             await command.reply({
                 content:
                     basic_moderation_info.type === "ban"
-                        ? `"This is the part where I kill you" - ${this.wheatley.wheatley}`
+                        ? `"This is the part where I kill you" — ${this.wheatley.emoji.me}`
                         : undefined,
                 embeds: [
                     new Discord.EmbedBuilder()
                         .setColor(colors.wheatley)
                         .setDescription(
                             build_description(
-                                `${this.wheatley.success} ***${user.displayName} was ${this.past_participle}***`,
+                                `${this.wheatley.emoji.success} ***${user.displayName} was ${this.past_participle}***`,
                                 command.is_slash() && reason ? `**Reason:** ${reason}` : null,
                                 (!this.is_once_off && duration_string === null) || reason === null
                                     ? `Remember to provide a ${[
@@ -670,7 +670,9 @@ export abstract class ModerationComponent extends BotComponent {
                 embeds: [
                     new Discord.EmbedBuilder()
                         .setColor(colors.wheatley)
-                        .setDescription(`${this.wheatley.success} ***${capitalize(this.past_participle)} all users***`),
+                        .setDescription(
+                            `${this.wheatley.emoji.success} ***${capitalize(this.past_participle)} all users***`,
+                        ),
                 ],
             });
         } catch (e) {
@@ -719,7 +721,8 @@ export abstract class ModerationComponent extends BotComponent {
                             .setColor(colors.wheatley)
                             .setDescription(
                                 build_description(
-                                    `${this.wheatley.success} ***${user.displayName} was un${this.past_participle}***`,
+                                    `${this.wheatley.emoji.success} ` +
+                                        `***${user.displayName} was un${this.past_participle}***`,
                                     command.is_slash() && reason ? `**Reason:** ${reason}` : null,
                                 ),
                             )
@@ -760,7 +763,7 @@ export abstract class ModerationComponent extends BotComponent {
             embeds: [
                 new Discord.EmbedBuilder()
                     .setColor(colors.alert_color)
-                    .setDescription(`${this.wheatley.error} ***${message}***`),
+                    .setDescription(`${this.wheatley.emoji.error} ***${message}***`),
             ],
         });
     }

--- a/src/components/moderation/moderation-control.ts
+++ b/src/components/moderation/moderation-control.ts
@@ -282,7 +282,7 @@ export default class ModerationControl extends BotComponent {
             embeds: [
                 new Discord.EmbedBuilder()
                     .setColor(colors.alert_color)
-                    .setDescription(`${this.wheatley.error} ***${message}***`),
+                    .setDescription(`${this.wheatley.emoji.error} ***${message}***`),
             ],
         });
     }
@@ -292,7 +292,7 @@ export default class ModerationControl extends BotComponent {
             embeds: [
                 new Discord.EmbedBuilder()
                     .setColor(colors.green)
-                    .setDescription(`${this.wheatley.success} ***${message}***`),
+                    .setDescription(`${this.wheatley.emoji.success} ***${message}***`),
             ],
         });
     }

--- a/src/components/moderation/modlogs.ts
+++ b/src/components/moderation/modlogs.ts
@@ -255,7 +255,7 @@ export default class Modlogs extends BotComponent {
             embeds: [
                 new Discord.EmbedBuilder()
                     .setColor(colors.alert_color)
-                    .setDescription(`${this.wheatley.error} ***${message}***`),
+                    .setDescription(`${this.wheatley.emoji.error} ***${message}***`),
             ],
         });
     }

--- a/src/components/moderation/note.ts
+++ b/src/components/moderation/note.ts
@@ -76,7 +76,7 @@ export default class Note extends ModerationComponent {
                         .setColor(colors.wheatley)
                         .setDescription(
                             build_description(
-                                `${this.wheatley.success} ***Note added for ${user.displayName}***`,
+                                `${this.wheatley.emoji.success} ***Note added for ${user.displayName}***`,
                                 command.is_slash() && reason ? `**Reason:** ${reason}` : null,
                             ),
                         )

--- a/src/wheatley.ts
+++ b/src/wheatley.ts
@@ -265,15 +265,15 @@ export class Wheatley {
     readonly freestanding: boolean;
 
     // Some emojis
-    readonly pepereally = "<:pepereally:643881257624666112>";
-    readonly stackoverflow_emote = "<:stackoverflow:1074747016644661258>";
-    readonly microsoft_emote = "<:microsoft:1165512917047853127>";
-    readonly tux_emote = "<:tux:1165505626894520361>";
-    readonly apple_emote = "<:apple:1165508607798943754>";
-    readonly tccpp_emote = "<:tccpp:865354975629279232>";
-    readonly success = "<:success:1138616548630745088>";
-    readonly error = "<:error:1138616562958483496>";
-    readonly wheatley = "<:wheatley:1147938076551827496>";
+    private emoji_map = {
+        success: "✅",
+        error: "❌",
+        access_denied: "🙅",
+        me: "🤖",
+    };
+    get emoji() {
+        return this.emoji_map;
+    }
 
     private log_channel: Discord.TextBasedChannel | null = null;
 
@@ -381,6 +381,7 @@ export class Wheatley {
 
                 this.discord_user = await this.client.users.fetch(config.id);
                 this.discord_guild = await this.client.guilds.fetch(config.guild);
+                await this.fetch_emoji();
                 await this.fetch_guild_info();
 
                 const command_set_builder = new CommandSetBuilder(this);
@@ -415,6 +416,15 @@ export class Wheatley {
         M.debug("Logging in");
 
         await this.client.login(config.token);
+    }
+
+    async fetch_emoji() {
+        if (this.client.application) {
+            await this.client.application.emojis.fetch();
+            for (const [key, value] of this.client.application.emojis.cache) {
+                this.emoji_map[value.name as keyof typeof this.emoji_map] = `<:${value.identifier}>`;
+            }
+        }
     }
 
     async fetch_guild_info() {

--- a/test/wiki-articles.ts
+++ b/test/wiki-articles.ts
@@ -10,12 +10,7 @@ describe("parse wiki articles", () => {
     for (const file_path of globSync(`${wiki_articles_path}/articles/**/*.md`, { withFileTypes: true })) {
         test(`${file_path.name} article should parse`, async () => {
             const content = await fs.promises.readFile(file_path.fullpath(), { encoding: "utf-8" });
-            parse_article(null, content, {
-                channels: {
-                    resources: { id: null },
-                    rules: { id: null },
-                },
-            } as any);
+            parse_article(null, content, str => str);
         });
     }
     for (const file_path of globSync(`${wiki_path}/src/**/*.md`, { withFileTypes: true })) {
@@ -23,12 +18,7 @@ describe("parse wiki articles", () => {
             const file_content = await fs.promises.readFile(file_path.fullpath(), { encoding: "utf-8" });
             const { data } = matter(file_content);
             if (data.preview) {
-                parse_article(null, data.preview, {
-                    channels: {
-                        resources: { id: null },
-                        rules: { id: null },
-                    },
-                } as any);
+                parse_article(null, data.preview, str => str);
             }
         });
     }


### PR DESCRIPTION
Fetch emoji from guild and application dynamically instead of hardcoding TCCPP emoji ids.
* Wheatley status emoji now use standard Unicode symbols as a fallback, replaced with application emoji of the same name on startup (if one exists).
* Wiki component now simply makes all guild emoji and channels (at least those with sufficiently sane names) available for use in articles.