### PR TITLE
Don't autoformat example json

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ solution currently is the following:
 
 Secrets and other bot info must be configured in the `config.json` file. An example looks like:
 
+<!-- prettier-ignore -->
 ```json
 {
   "id": "<bot id>",


### PR DESCRIPTION
it keeps messing up the comment formatting…