### PR TITLE
Make database readonly

### DIFF
--- a/src/components/moderation/moderation-common.ts
+++ b/src/components/moderation/moderation-common.ts
@@ -162,7 +162,7 @@ export abstract class ModerationComponent extends BotComponent {
         return false;
     }
 
-    protected database = unwrap(this.wheatley.database).create_proxy<{
+    protected database = this.wheatley.database.create_proxy<{
         component_state: moderation_state;
         moderations: moderation_entry;
     }>();

--- a/src/components/moderation/moderation-control.ts
+++ b/src/components/moderation/moderation-control.ts
@@ -16,7 +16,7 @@ import { TextBasedCommand } from "../../command-abstractions/text-based-command.
 import { unwrap } from "../../utils/misc.js";
 
 export default class ModerationControl extends BotComponent {
-    private database = unwrap(this.wheatley.database).create_proxy<{
+    private database = this.wheatley.database.create_proxy<{
         moderations: moderation_entry;
     }>();
 

--- a/src/components/moderation/modlogs.ts
+++ b/src/components/moderation/modlogs.ts
@@ -20,7 +20,7 @@ import { unwrap } from "../../utils/misc.js";
 const moderations_per_page = 5;
 
 export default class Modlogs extends BotComponent {
-    private database = unwrap(this.wheatley.database).create_proxy<{
+    private database = this.wheatley.database.create_proxy<{
         moderations: moderation_entry;
     }>();
 

--- a/src/components/moderation/modmail.ts
+++ b/src/components/moderation/modmail.ts
@@ -36,7 +36,7 @@ export default class Modmail extends BotComponent {
 
     readonly monke_set = new SelfClearingMap<Discord.Snowflake, number>(HOUR, HOUR);
 
-    private database = unwrap(this.wheatley.database).create_proxy<{
+    private database = this.wheatley.database.create_proxy<{
         component_state: moderation_state;
     }>();
 

--- a/src/components/moderation/modstats.ts
+++ b/src/components/moderation/modstats.ts
@@ -13,7 +13,7 @@ import { unwrap } from "../../utils/misc.js";
 import { capitalize } from "../../utils/strings.js";
 
 export default class ModStats extends BotComponent {
-    private database = unwrap(this.wheatley.database).create_proxy<{
+    private database = this.wheatley.database.create_proxy<{
         moderations: moderation_entry;
     }>();
 

--- a/src/components/moderation/purge.ts
+++ b/src/components/moderation/purge.ts
@@ -41,7 +41,7 @@ export default class Purge extends BotComponent {
     // boolean flag indicates whether to continue, serves as a stop token
     tasks = new SelfClearingMap<string, [boolean, Discord.InteractionResponse | null]>(2 * HOUR, 30 * MINUTE);
 
-    private database = unwrap(this.wheatley.database).create_proxy<{
+    private database = this.wheatley.database.create_proxy<{
         message_database: message_database_entry;
     }>();
 

--- a/src/components/nodistractions.ts
+++ b/src/components/nodistractions.ts
@@ -71,7 +71,7 @@ export default class Nodistractions extends BotComponent {
     undistract_queue: no_distraction_entry[] = [];
     timer: NodeJS.Timeout | null = null;
 
-    private database = unwrap(this.wheatley.database).create_proxy<{
+    private database = this.wheatley.database.create_proxy<{
         nodistractions: no_distraction_entry;
     }>();
 

--- a/src/components/notify-about-formerly-banned-users.ts
+++ b/src/components/notify-about-formerly-banned-users.ts
@@ -9,7 +9,7 @@ import { moderation_entry } from "./moderation/schemata.js";
 import { unwrap } from "../utils/misc.js";
 
 export default class NotifyAboutFormerlyBannedUsers extends BotComponent {
-    private database = unwrap(this.wheatley.database).create_proxy<{
+    private database = this.wheatley.database.create_proxy<{
         moderations: moderation_entry;
     }>();
 

--- a/src/components/pin-archive.ts
+++ b/src/components/pin-archive.ts
@@ -29,7 +29,7 @@ type pin_archive_entry = {
 export default class PinArchive extends BotComponent {
     mutex = new KeyedMutexSet<string>();
 
-    private database = unwrap(this.wheatley.database).create_proxy<{
+    private database = this.wheatley.database.create_proxy<{
         pins: pin_entry;
         pin_archive: pin_archive_entry;
     }>();

--- a/src/components/role-manager.ts
+++ b/src/components/role-manager.ts
@@ -36,7 +36,7 @@ export default class RoleManager extends BotComponent {
     // roles that will not be re-applied on join
     blacklisted_roles: Set<string>;
 
-    private database = unwrap(this.wheatley.database).create_proxy<{
+    private database = this.wheatley.database.create_proxy<{
         user_roles: user_role_entry;
     }>();
 

--- a/src/modules/tccpp/components/april1/buzzwords.ts
+++ b/src/modules/tccpp/components/april1/buzzwords.ts
@@ -177,7 +177,7 @@ export default class Buzzwords extends BotComponent {
     timeout: NodeJS.Timeout | null = null;
     interval: NodeJS.Timeout | null = null;
 
-    private database = unwrap(this.wheatley.database).create_proxy<{
+    private database = this.wheatley.database.create_proxy<{
         buzzword_scoreboard: buzzword_scoreboard_entry;
     }>();
 

--- a/src/modules/tccpp/components/days-since-last-incident.ts
+++ b/src/modules/tccpp/components/days-since-last-incident.ts
@@ -17,7 +17,7 @@ export default class DaysSinceLastIncident extends BotComponent {
     last_time = "";
     timer: NodeJS.Timeout;
 
-    private database = unwrap(this.wheatley.database).create_proxy<{
+    private database = this.wheatley.database.create_proxy<{
         moderations: moderation_entry;
     }>();
 

--- a/src/modules/tccpp/components/roulette.ts
+++ b/src/modules/tccpp/components/roulette.ts
@@ -23,7 +23,7 @@ export default class Roulette extends BotComponent {
     // user id -> streak count
     readonly streaks = new SelfClearingMap<string, number>(60 * MINUTE);
 
-    private database = unwrap(this.wheatley.database).create_proxy<{
+    private database = this.wheatley.database.create_proxy<{
         roulette_leaderboard: roulette_leaderboard_entry;
     }>();
 

--- a/src/modules/tccpp/components/server-suggestion-tracker.ts
+++ b/src/modules/tccpp/components/server-suggestion-tracker.ts
@@ -43,7 +43,7 @@ type server_suggestion_entry = {
 export default class ServerSuggestionTracker extends BotComponent {
     recovering = true;
 
-    private database = unwrap(this.wheatley.database).create_proxy<{
+    private database = this.wheatley.database.create_proxy<{
         component_state: server_suggestions_state;
         server_suggestions: server_suggestion_entry;
     }>();

--- a/src/modules/tccpp/components/skill-role-suggestion.ts
+++ b/src/modules/tccpp/components/skill-role-suggestion.ts
@@ -39,7 +39,7 @@ type skill_suggestion_thread_entry = {
 export default class SkillRoleSuggestion extends BotComponent {
     readonly target_map = new SelfClearingMap<string, interaction_context>(15 * MINUTE);
 
-    private database = unwrap(this.wheatley.database).create_proxy<{
+    private database = this.wheatley.database.create_proxy<{
         skill_role_suggestions: skill_suggestion_entry;
         skill_role_threads: skill_suggestion_thread_entry;
     }>();
@@ -171,7 +171,7 @@ export default class SkillRoleSuggestion extends BotComponent {
         member: Discord.GuildMember,
         suggestion_time: number,
     ): Promise<Discord.ForumThreadChannel> {
-        await unwrap(this.wheatley.database).lock();
+        await this.wheatley.database.lock();
         try {
             const entry = await this.database.skill_role_threads.findOne({
                 user_id: member.user.id,
@@ -222,7 +222,7 @@ export default class SkillRoleSuggestion extends BotComponent {
             await thread.setAppliedTags(tags);
             return thread;
         } finally {
-            unwrap(this.wheatley.database).unlock();
+            this.wheatley.database.unlock();
         }
     }
 

--- a/src/modules/tccpp/components/starboard.ts
+++ b/src/modules/tccpp/components/starboard.ts
@@ -75,7 +75,7 @@ export default class Starboard extends BotComponent {
 
     excluded_channels: Set<string>;
 
-    private database = unwrap(this.wheatley.database).create_proxy<{
+    private database = this.wheatley.database.create_proxy<{
         component_state: starboard_state;
         auto_delete_threshold_notifications: auto_delete_threshold_notifications;
         starboard_entries: starboard_entry;
@@ -302,7 +302,7 @@ export default class Starboard extends BotComponent {
         M.log(`${action} ${message.url} for ${trigger_reaction.count} ${trigger_reaction.emoji.name} reactions`);
         let flag_message: Discord.Message | null = null;
         try {
-            await unwrap(this.wheatley.database).lock();
+            await this.wheatley.database.lock();
             if (
                 do_delete ||
                 !(await this.database.auto_delete_threshold_notifications.findOne({ message: message.id }))
@@ -332,7 +332,7 @@ export default class Starboard extends BotComponent {
                 this.wheatley.critical_error(e);
             }
         } finally {
-            unwrap(this.wheatley.database).unlock();
+            this.wheatley.database.unlock();
         }
         if (do_delete) {
             await this.database.auto_deletes.insertOne({

--- a/src/modules/tccpp/components/the-button.ts
+++ b/src/modules/tccpp/components/the-button.ts
@@ -67,7 +67,7 @@ export default class TheButton extends BotComponent {
     last_reset: number;
     longest_time_without_reset: number;
 
-    private database = unwrap(this.wheatley.database).create_proxy<{
+    private database = this.wheatley.database.create_proxy<{
         component_state: the_button_state;
         button_scoreboard: the_button_scoreboard_entry;
     }>();

--- a/src/wheatley.ts
+++ b/src/wheatley.ts
@@ -236,7 +236,10 @@ export class Wheatley {
 
     private command_handler: CommandHandler;
 
-    database: WheatleyDatabase | null;
+    private db: WheatleyDatabase | null;
+    get database() {
+        return unwrap(this.db);
+    }
 
     // whether wheatley is ready (client is ready + wheatley has set up)
     ready = false;
@@ -263,22 +266,22 @@ export class Wheatley {
     TCCPP: Discord.Guild;
     user: Discord.User;
 
-    log_channel: Discord.TextBasedChannel | null = null;
+    private log_channel: Discord.TextBasedChannel | null = null;
 
-    channels: {
+    readonly channels: {
         // ["prototype"] gets the instance type, eliminating the `typeof`. InstanceType<T> doesn't work for a protected
         // constructor, weirdly.
         [k in keyof typeof channels_map]: (typeof channels_map)[k][1]["prototype"];
     } = {} as any;
 
-    categories: {
+    readonly categories: {
         [k in keyof typeof categories_map]: Discord.CategoryChannel;
     } = {} as any;
 
-    roles: {
+    readonly roles: {
         [k in keyof typeof roles_map]: Discord.Role;
     } = {} as any;
-    skill_roles: {
+    readonly skill_roles: {
         [k in keyof typeof skill_roles_map]: Discord.Role;
     } = {} as any;
 
@@ -293,7 +296,7 @@ export class Wheatley {
 
     private mom_ping: string;
 
-    config: {
+    readonly config: {
         [key: string]: any;
     };
 
@@ -330,7 +333,7 @@ export class Wheatley {
     async setup(config: core_config) {
         assert(this.freestanding || config.mongo, "Missing MongoDB credentials");
         if (config.mongo) {
-            this.database = await WheatleyDatabase.create(config.mongo);
+            this.db = await WheatleyDatabase.create(config.mongo);
             await this.migrate_db(this.database);
         }
         if (config.metrics) {


### PR DESCRIPTION
* cleans up client code by moving all the `unwrap()` calls into the getter
* also adds a couple `private` and `readonly` modifiers