### PR TITLE
Refactor channel access

### DIFF
--- a/src/bot-utilities.ts
+++ b/src/bot-utilities.ts
@@ -236,4 +236,10 @@ export class BotUtilities {
         assert(channel instanceof Discord.ForumChannel, `Channel ${channel} (${id}) not of the expected type`);
         return channel;
     }
+
+    async get_thread_channel(id: string) {
+        const channel = await this.wheatley.client.channels.fetch(id);
+        assert(channel instanceof Discord.ThreadChannel, `Channel ${channel} (${id}) not of the expected type`);
+        return channel;
+    }
 }

--- a/src/bot-utilities.ts
+++ b/src/bot-utilities.ts
@@ -224,4 +224,16 @@ export class BotUtilities {
                 attachments.length + other_attachments.length == 0 ? undefined : [...attachments, ...other_attachments],
         };
     }
+
+    async get_channel(id: string) {
+        const channel = await this.wheatley.client.channels.fetch(id);
+        assert(channel instanceof Discord.TextChannel, `Channel ${channel} (${id}) not of the expected type`);
+        return channel;
+    }
+
+    async get_forum_channel(id: string) {
+        const channel = await this.wheatley.client.channels.fetch(id);
+        assert(channel instanceof Discord.ForumChannel, `Channel ${channel} (${id}) not of the expected type`);
+        return channel;
+    }
 }

--- a/src/components/anti-executable.ts
+++ b/src/components/anti-executable.ts
@@ -10,6 +10,7 @@ import { build_description, capitalize } from "../utils/strings.js";
 import { Virustotal } from "../infra/virustotal.js";
 import Mute from "./moderation/mute.js";
 import { unwrap } from "../utils/misc.js";
+import { CommandSetBuilder } from "../command-abstractions/command-set-builder.js";
 
 const ACTION_THRESHOLD = 5;
 
@@ -30,7 +31,7 @@ export default class AntiExecutable extends BotComponent {
         }
     }
 
-    override async setup(commands: any) {
+    override async setup(commands: CommandSetBuilder) {
         this.staff_flag_log = await this.utilities.get_channel(this.wheatley.channels.staff_flag_log);
         this.staff_action_log = await this.utilities.get_channel(this.wheatley.channels.staff_action_log);
     }

--- a/src/components/anti-invite-links.ts
+++ b/src/components/anti-invite-links.ts
@@ -26,6 +26,12 @@ export default class AntiInviteLinks extends BotComponent {
         return true;
     }
 
+    private staff_flag_log: Discord.TextChannel;
+
+    override async setup(commands: any) {
+        this.staff_flag_log = await this.utilities.get_channel(this.wheatley.channels.staff_flag_log);
+    }
+
     async member_is_proficient_or_higher(member: Discord.GuildMember | null) {
         if (!member) {
             return false;
@@ -52,7 +58,7 @@ export default class AntiInviteLinks extends BotComponent {
             await message.delete();
             assert(!(message.channel instanceof Discord.PartialGroupDMChannel));
             await message.channel.send(`<@${message.author.id}> Please do not send invite links`);
-            await this.wheatley.channels.staff_flag_log.send({
+            await this.staff_flag_log.send({
                 content: `:warning: Invite link deleted`,
                 ...quote,
             });

--- a/src/components/anti-invite-links.ts
+++ b/src/components/anti-invite-links.ts
@@ -4,6 +4,7 @@ import * as Discord from "discord.js";
 
 import { BotComponent } from "../bot-component.js";
 import { departialize } from "../utils/discord.js";
+import { CommandSetBuilder } from "../command-abstractions/command-set-builder.js";
 
 const INVITE_RE =
     /(?:(?:discord(?:app)?|disboard)\.(?:gg|(?:com|org|me)\/(?:invite|server\/join))|(?<!\w)\.gg)\/(\S+)/i;
@@ -28,7 +29,7 @@ export default class AntiInviteLinks extends BotComponent {
 
     private staff_flag_log: Discord.TextChannel;
 
-    override async setup(commands: any) {
+    override async setup(commands: CommandSetBuilder) {
         this.staff_flag_log = await this.utilities.get_channel(this.wheatley.channels.staff_flag_log);
     }
 

--- a/src/components/code.ts
+++ b/src/components/code.ts
@@ -26,7 +26,7 @@ export default class Code extends BotComponent {
     }
 
     static make_code_formatting_embeds(wheatley: Wheatley, channel: Discord.TextBasedChannel): Discord.APIEmbedField[] {
-        const is_c = [wheatley.channels.c_help.id, wheatley.channels.c_help_text.id].includes(
+        const is_c = [wheatley.channels.c_help, wheatley.channels.c_help_text].includes(
             wheatley.top_level_channel(channel),
         );
         return [

--- a/src/components/emoji-log.ts
+++ b/src/components/emoji-log.ts
@@ -7,8 +7,13 @@ import { colors } from "../common.js";
 import { BotComponent } from "../bot-component.js";
 
 export default class EmojiLog extends BotComponent {
+    private staff_action_log: Discord.TextChannel;
+
+    override async setup(commands: any) {
+        this.staff_action_log = await this.utilities.get_channel(this.wheatley.channels.staff_action_log);
+    }
     override async on_emoji_create(emoji: Discord.GuildEmoji) {
-        await this.wheatley.channels.staff_action_log.send({
+        await this.staff_action_log.send({
             embeds: [
                 new Discord.EmbedBuilder()
                     .setTitle("Emoji Created")
@@ -24,7 +29,7 @@ export default class EmojiLog extends BotComponent {
     }
 
     override async on_emoji_delete(emoji: Discord.GuildEmoji) {
-        await this.wheatley.channels.staff_action_log.send({
+        await this.staff_action_log.send({
             embeds: [
                 new Discord.EmbedBuilder()
                     .setTitle("Emoji Removed")
@@ -40,7 +45,7 @@ export default class EmojiLog extends BotComponent {
     }
 
     override async on_emoji_update(old_emoji: Discord.GuildEmoji, new_emoji: Discord.GuildEmoji) {
-        await this.wheatley.channels.staff_action_log.send({
+        await this.staff_action_log.send({
             embeds: [
                 new Discord.EmbedBuilder()
                     .setTitle("Emoji Updated")

--- a/src/components/emoji-log.ts
+++ b/src/components/emoji-log.ts
@@ -5,13 +5,15 @@ import { strict as assert } from "assert";
 import { M } from "../utils/debugging-and-logging.js";
 import { colors } from "../common.js";
 import { BotComponent } from "../bot-component.js";
+import { CommandSetBuilder } from "../command-abstractions/command-set-builder.js";
 
 export default class EmojiLog extends BotComponent {
     private staff_action_log: Discord.TextChannel;
 
-    override async setup(commands: any) {
+    override async setup(commands: CommandSetBuilder) {
         this.staff_action_log = await this.utilities.get_channel(this.wheatley.channels.staff_action_log);
     }
+
     override async on_emoji_create(emoji: Discord.GuildEmoji) {
         await this.staff_action_log.send({
             embeds: [

--- a/src/components/join-leave-log.ts
+++ b/src/components/join-leave-log.ts
@@ -9,8 +9,13 @@ import { build_description, time_to_human } from "../utils/strings.js";
 import { equal } from "../utils/arrays.js";
 
 export default class JoinLeaveLog extends BotComponent {
+    private staff_member_log: Discord.TextChannel;
+
+    override async setup(commands: any) {
+        this.staff_member_log = await this.utilities.get_channel(this.wheatley.channels.staff_member_log);
+    }
     override async on_guild_member_add(member: Discord.GuildMember) {
-        this.wheatley.llog(this.wheatley.channels.staff_member_log, {
+        this.wheatley.llog(this.staff_member_log, {
             embeds: [
                 new Discord.EmbedBuilder()
                     .setTitle("Member Joined")
@@ -34,7 +39,7 @@ export default class JoinLeaveLog extends BotComponent {
     }
 
     override async on_guild_member_remove(member: Discord.GuildMember | Discord.PartialGuildMember) {
-        this.wheatley.llog(this.wheatley.channels.staff_member_log, {
+        this.wheatley.llog(this.staff_member_log, {
             embeds: [
                 new Discord.EmbedBuilder()
                     .setTitle("Member Left")
@@ -74,7 +79,7 @@ export default class JoinLeaveLog extends BotComponent {
             extra_description.push(`Old display name: ${old_member.displayName}`);
             extra_description.push(`New display name: ${new_member.displayName}`);
         }
-        this.wheatley.llog(this.wheatley.channels.staff_member_log, {
+        this.wheatley.llog(this.staff_member_log, {
             embeds: [
                 new Discord.EmbedBuilder()
                     .setTitle("Member Updated")

--- a/src/components/join-leave-log.ts
+++ b/src/components/join-leave-log.ts
@@ -7,13 +7,15 @@ import { colors } from "../common.js";
 import { BotComponent } from "../bot-component.js";
 import { build_description, time_to_human } from "../utils/strings.js";
 import { equal } from "../utils/arrays.js";
+import { CommandSetBuilder } from "../command-abstractions/command-set-builder.js";
 
 export default class JoinLeaveLog extends BotComponent {
     private staff_member_log: Discord.TextChannel;
 
-    override async setup(commands: any) {
+    override async setup(commands: CommandSetBuilder) {
         this.staff_member_log = await this.utilities.get_channel(this.wheatley.channels.staff_member_log);
     }
+
     override async on_guild_member_add(member: Discord.GuildMember) {
         this.wheatley.llog(this.staff_member_log, {
             embeds: [

--- a/src/components/moderation/ban.ts
+++ b/src/components/moderation/ban.ts
@@ -23,6 +23,7 @@ export default class Ban extends ModerationComponent {
     }
 
     override async setup(commands: CommandSetBuilder) {
+        await super.setup(commands);
         commands.add(
             new TextBasedCommandBuilder("ban", EarlyReplyMode.visible)
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)

--- a/src/components/moderation/kick.ts
+++ b/src/components/moderation/kick.ts
@@ -27,6 +27,7 @@ export default class Kick extends ModerationComponent {
     }
 
     override async setup(commands: CommandSetBuilder) {
+        await super.setup(commands);
         commands.add(
             new TextBasedCommandBuilder("kick", EarlyReplyMode.visible)
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)

--- a/src/components/moderation/massban.ts
+++ b/src/components/moderation/massban.ts
@@ -4,10 +4,16 @@ import { M } from "../../utils/debugging-and-logging.js";
 import { colors } from "../../common.js";
 import { BotComponent } from "../../bot-component.js";
 import { Wheatley } from "../../wheatley.js";
+import { CommandSetBuilder } from "../../command-abstractions/command-set-builder.js";
 
 const snowflake_re = /\b\d{10,}\b/g;
 
 export default class Massban extends BotComponent {
+    private staff_action_log: Discord.TextChannel;
+
+    override async setup(commands: CommandSetBuilder) {
+        this.staff_action_log = await this.utilities.get_channel(this.wheatley.channels.staff_action_log);
+    }
     override async on_message_create(message: Discord.Message) {
         try {
             // Ignore self, bots, and messages outside TCCPP (e.g. dm's)
@@ -50,7 +56,7 @@ export default class Massban extends BotComponent {
                 .setTitle(`<@!${msg.author.id}> banned ${ids.length} users`)
                 .setDescription(`\`\`\`\n${ids.join("\n")}\n\`\`\``)
                 .setTimestamp();
-            await this.wheatley.channels.staff_action_log.send({ embeds: [embed] });
+            await this.staff_action_log.send({ embeds: [embed] });
         }
     }
 }

--- a/src/components/moderation/moderation-common.ts
+++ b/src/components/moderation/moderation-common.ts
@@ -29,6 +29,7 @@ import {
 import { set_interval } from "../../utils/node.js";
 
 import { get_random_array_element } from "../../utils/arrays.js";
+import { CommandSetBuilder } from "../../command-abstractions/command-set-builder.js";
 
 /*
  * !mute !unmute
@@ -173,7 +174,7 @@ export abstract class ModerationComponent extends BotComponent {
     sleep_list: SleepList<mongo.WithId<moderation_entry>, mongo.BSON.ObjectId>;
     timer: NodeJS.Timer | null = null;
 
-    override async setup(commands: any) {
+    override async setup(commands: CommandSetBuilder) {
         this.staff_action_log = await this.utilities.get_channel(this.wheatley.channels.staff_action_log);
         this.public_action_log = await this.utilities.get_channel(this.wheatley.channels.public_action_log);
     }

--- a/src/components/moderation/moderation-control.ts
+++ b/src/components/moderation/moderation-control.ts
@@ -19,8 +19,12 @@ export default class ModerationControl extends BotComponent {
     private database = this.wheatley.database.create_proxy<{
         moderations: moderation_entry;
     }>();
+    private staff_action_log: Discord.TextChannel;
+    private public_action_log: Discord.TextChannel;
 
     override async setup(commands: CommandSetBuilder) {
+        this.staff_action_log = await this.utilities.get_channel(this.wheatley.channels.staff_action_log);
+        this.public_action_log = await this.utilities.get_channel(this.wheatley.channels.public_action_log);
         commands.add(
             new TextBasedCommandBuilder("reason", EarlyReplyMode.visible)
                 .set_description("Update the reason for a case")
@@ -132,7 +136,7 @@ export default class ModerationControl extends BotComponent {
         );
         if (res) {
             await this.reply_with_success(command, "Reason updated");
-            await this.wheatley.channels.staff_action_log.send({
+            await this.staff_action_log.send({
                 embeds: [
                     Modlogs.case_summary(res, await this.wheatley.client.users.fetch(res.user), true).setTitle(
                         `Case ${res.case_number} reason updated`,
@@ -140,7 +144,7 @@ export default class ModerationControl extends BotComponent {
                 ],
             });
             if (res.type !== "note") {
-                await this.wheatley.channels.public_action_log.send({
+                await this.public_action_log.send({
                     embeds: [
                         Modlogs.case_summary(res, await this.wheatley.client.users.fetch(res.user), false).setTitle(
                             `Case ${res.case_number} reason updated`,
@@ -168,7 +172,7 @@ export default class ModerationControl extends BotComponent {
         );
         if (res) {
             await this.reply_with_success(command, "Context updated");
-            await this.wheatley.channels.staff_action_log.send({
+            await this.staff_action_log.send({
                 embeds: [
                     Modlogs.case_summary(res, await this.wheatley.client.users.fetch(res.user), true).setTitle(
                         `Case ${res.case_number} context updated`,
@@ -206,7 +210,7 @@ export default class ModerationControl extends BotComponent {
             await this.reply_with_success(command, "Duration updated");
             // Update sleep lists and remove moderation if needed
             this.wheatley.event_hub.emit("update_moderation", res);
-            await this.wheatley.channels.staff_action_log.send({
+            await this.staff_action_log.send({
                 embeds: [
                     Modlogs.case_summary(res, await this.wheatley.client.users.fetch(res.user), true).setTitle(
                         `Case ${res.case_number} duration updated`,
@@ -214,7 +218,7 @@ export default class ModerationControl extends BotComponent {
                 ],
             });
             if (res.type !== "note") {
-                await this.wheatley.channels.public_action_log.send({
+                await this.public_action_log.send({
                     embeds: [
                         Modlogs.case_summary(res, await this.wheatley.client.users.fetch(res.user), false).setTitle(
                             `Case ${res.case_number} duration updated`,
@@ -249,7 +253,7 @@ export default class ModerationControl extends BotComponent {
             await this.reply_with_success(command, "Case expunged");
             // Update sleep lists and remove moderation if needed
             this.wheatley.event_hub.emit("update_moderation", res);
-            await this.wheatley.channels.staff_action_log.send({
+            await this.staff_action_log.send({
                 embeds: [
                     Modlogs.case_summary(res, await this.wheatley.client.users.fetch(res.user), true).setTitle(
                         `Case ${res.case_number} expunged`,
@@ -257,7 +261,7 @@ export default class ModerationControl extends BotComponent {
                 ],
             });
             if (res.type !== "note") {
-                await this.wheatley.channels.public_action_log.send({
+                await this.public_action_log.send({
                     embeds: [
                         Modlogs.case_summary(res, await this.wheatley.client.users.fetch(res.user), false).setTitle(
                             `Case ${res.case_number} expunged`,

--- a/src/components/moderation/modmail.ts
+++ b/src/components/moderation/modmail.ts
@@ -43,8 +43,14 @@ export default class Modmail extends BotComponent {
     private database = this.wheatley.database.create_proxy<{
         component_state: moderation_state;
     }>();
+    private rules: Discord.TextChannel;
+    private mods: Discord.TextChannel;
+    private staff_member_log: Discord.TextChannel;
 
     override async setup(commands: CommandSetBuilder) {
+        this.rules = await this.utilities.get_channel(this.wheatley.channels.rules);
+        this.mods = await this.utilities.get_channel(this.wheatley.channels.mods);
+        this.staff_member_log = await this.utilities.get_channel(this.wheatley.channels.staff_member_log);
         commands.add(
             new TextBasedCommandBuilder("wsetupmodmailsystem", EarlyReplyMode.none)
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
@@ -98,7 +104,7 @@ export default class Modmail extends BotComponent {
                 const member = await this.wheatley.guild.members.fetch(interaction.member.user.id);
                 // make the thread
                 const id = await this.increment_modmail_id();
-                const thread = await this.wheatley.channels.rules.threads.create({
+                const thread = await this.rules.threads.create({
                     type: Discord.ChannelType.PrivateThread,
                     invitable: false,
                     name: `Modmail #${id}`,
@@ -121,7 +127,7 @@ export default class Modmail extends BotComponent {
                     name: member.user.tag,
                     iconURL: member.displayAvatarURL(),
                 });
-                await this.wheatley.channels.mods.send({
+                await this.mods.send({
                     content: make_url(thread),
                     embeds: [notification_embed],
                 });
@@ -380,7 +386,7 @@ export default class Modmail extends BotComponent {
         if (body) {
             embed.setDescription(body);
         }
-        await this.wheatley.channels.staff_member_log.send({
+        await this.staff_member_log.send({
             embeds: [embed],
         });
     }

--- a/src/components/moderation/modstats.ts
+++ b/src/components/moderation/modstats.ts
@@ -64,10 +64,7 @@ export default class ModStats extends BotComponent {
             await command.reply(`<@${moderator.id}> is not a moderator`);
             return;
         }
-        if (
-            !this.wheatley.is_authorized_mod(command.user) &&
-            command.channel_id != this.bot_spam.id
-        ) {
+        if (!this.wheatley.is_authorized_mod(command.user) && command.channel_id != this.bot_spam.id) {
             await command.reply(`Please use in <#${this.bot_spam.id}>`, true);
             return;
         }

--- a/src/components/moderation/modstats.ts
+++ b/src/components/moderation/modstats.ts
@@ -16,8 +16,10 @@ export default class ModStats extends BotComponent {
     private database = this.wheatley.database.create_proxy<{
         moderations: moderation_entry;
     }>();
+    private bot_spam: Discord.TextChannel;
 
     override async setup(commands: CommandSetBuilder) {
+        this.bot_spam = await this.utilities.get_channel(this.wheatley.channels.bot_spam);
         commands.add(
             new TextBasedCommandBuilder("modstats", EarlyReplyMode.none)
                 .set_description("Moderator stats")
@@ -64,9 +66,9 @@ export default class ModStats extends BotComponent {
         }
         if (
             !this.wheatley.is_authorized_mod(command.user) &&
-            command.channel_id != this.wheatley.channels.bot_spam.id
+            command.channel_id != this.bot_spam.id
         ) {
-            await command.reply(`Please use in <#${this.wheatley.channels.bot_spam.id}>`, true);
+            await command.reply(`Please use in <#${this.bot_spam.id}>`, true);
             return;
         }
         await command.do_early_reply_if_slash(false);

--- a/src/components/moderation/mute.ts
+++ b/src/components/moderation/mute.ts
@@ -25,6 +25,7 @@ export default class Mute extends ModerationComponent {
     }
 
     override async setup(commands: CommandSetBuilder) {
+        await super.setup(commands);
         commands.add(
             new TextBasedCommandBuilder("mute", EarlyReplyMode.visible)
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)

--- a/src/components/moderation/note.ts
+++ b/src/components/moderation/note.ts
@@ -26,6 +26,7 @@ export default class Note extends ModerationComponent {
     }
 
     override async setup(commands: CommandSetBuilder) {
+        await super.setup(commands);
         commands.add(
             new TextBasedCommandBuilder("note", EarlyReplyMode.ephemeral)
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)

--- a/src/components/moderation/purge.ts
+++ b/src/components/moderation/purge.ts
@@ -43,8 +43,12 @@ export default class Purge extends BotComponent {
     private database = this.wheatley.database.create_proxy<{
         message_database: message_database_entry;
     }>();
+    private staff_flag_log: Discord.TextChannel;
+    private welcome: Discord.TextChannel;
 
     override async setup(commands: CommandSetBuilder) {
+        this.staff_flag_log = await this.utilities.get_channel(this.wheatley.channels.staff_flag_log);
+        this.welcome = await this.utilities.get_channel(this.wheatley.channels.welcome);
         // purge count
         // purge after
         // purge range
@@ -362,7 +366,7 @@ export default class Purge extends BotComponent {
                 "author.id": user.id,
                 guild: this.wheatley.guild.id,
                 channel: {
-                    $nin: [this.wheatley.channels.staff_flag_log.id, this.wheatley.channels.welcome.id],
+                    $nin: [this.staff_flag_log.id, this.welcome.id],
                 },
                 timestamp: {
                     $gte: Date.now() - timeframe,

--- a/src/components/moderation/timeout.ts
+++ b/src/components/moderation/timeout.ts
@@ -23,6 +23,7 @@ export default class Timeout extends ModerationComponent {
     }
 
     override async setup(commands: CommandSetBuilder) {
+        await super.setup(commands);
         commands.add(
             new TextBasedCommandBuilder("timeout", EarlyReplyMode.visible)
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)

--- a/src/components/moderation/voice-deputies.ts
+++ b/src/components/moderation/voice-deputies.ts
@@ -14,8 +14,10 @@ import { unwrap } from "../../utils/misc.js";
 
 export default class VoiceDeputies extends BotComponent {
     private recently_in_voice = new SelfClearingSet<string>(5 * MINUTE);
+    private voice_hotline: Discord.TextChannel;
 
     override async setup(commands: CommandSetBuilder) {
+        this.voice_hotline = await this.utilities.get_channel(this.wheatley.channels.voice_hotline);
         commands.add(
             new TextBasedCommandBuilder("voice", EarlyReplyMode.ephemeral)
                 .set_permissions(Discord.PermissionFlagsBits.MoveMembers | Discord.PermissionFlagsBits.MuteMembers)
@@ -121,7 +123,7 @@ export default class VoiceDeputies extends BotComponent {
         }
 
         await target.timeout(3 * HOUR);
-        await this.wheatley.channels.voice_hotline.send({
+        await this.voice_hotline.send({
             content: `<@&${this.wheatley.roles.moderators.id}>`,
             embeds: [
                 new Discord.EmbedBuilder()
@@ -160,15 +162,15 @@ export default class VoiceDeputies extends BotComponent {
         if (entry.action == Discord.AuditLogEvent.MemberUpdate) {
             for (const change of entry.changes) {
                 if (change.key == "mute") {
-                    await this.wheatley.channels.voice_hotline.send(
+                    await this.voice_hotline.send(
                         `<@${entry.targetId}> was ${change.old ? "unmuted" : "muted"} by <@${entry.executorId}>`,
                     );
                 }
             }
         } else if (entry.action == Discord.AuditLogEvent.MemberMove) {
-            await this.wheatley.channels.voice_hotline.send(`user was moved by <@${entry.executorId}>`);
+            await this.voice_hotline.send(`user was moved by <@${entry.executorId}>`);
         } else if (entry.action == Discord.AuditLogEvent.MemberDisconnect) {
-            await this.wheatley.channels.voice_hotline.send(`user was disconnected by <@${entry.executorId}>`);
+            await this.voice_hotline.send(`user was disconnected by <@${entry.executorId}>`);
         }
     }
 

--- a/src/components/moderation/warn.ts
+++ b/src/components/moderation/warn.ts
@@ -24,6 +24,7 @@ export default class Warn extends ModerationComponent {
     }
 
     override async setup(commands: CommandSetBuilder) {
+        await super.setup(commands);
         commands.add(
             new TextBasedCommandBuilder("warn", EarlyReplyMode.visible)
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)

--- a/src/components/notify-about-brand-new-users.ts
+++ b/src/components/notify-about-brand-new-users.ts
@@ -5,15 +5,17 @@ import { colors, MINUTE } from "../common.js";
 import { BotComponent } from "../bot-component.js";
 import { Wheatley } from "../wheatley.js";
 import { discord_timestamp } from "../utils/discord.js";
+import { CommandSetBuilder } from "../command-abstractions/command-set-builder.js";
 
 const NEW_USER_THRESHOLD = MINUTE * 30;
 
 export default class NotifyAboutBrandNewUsers extends BotComponent {
     private welcome: Discord.TextChannel;
 
-    override async setup(commands: any) {
+    override async setup(commands: CommandSetBuilder) {
         this.welcome = await this.utilities.get_channel(this.wheatley.channels.welcome);
     }
+
     async notify_about_brand_new_user(member: Discord.GuildMember) {
         const embed = new Discord.EmbedBuilder()
             .setColor(colors.alert_color)

--- a/src/components/notify-about-brand-new-users.ts
+++ b/src/components/notify-about-brand-new-users.ts
@@ -9,6 +9,11 @@ import { discord_timestamp } from "../utils/discord.js";
 const NEW_USER_THRESHOLD = MINUTE * 30;
 
 export default class NotifyAboutBrandNewUsers extends BotComponent {
+    private welcome: Discord.TextChannel;
+
+    override async setup(commands: any) {
+        this.welcome = await this.utilities.get_channel(this.wheatley.channels.welcome);
+    }
     async notify_about_brand_new_user(member: Discord.GuildMember) {
         const embed = new Discord.EmbedBuilder()
             .setColor(colors.alert_color)
@@ -25,7 +30,7 @@ export default class NotifyAboutBrandNewUsers extends BotComponent {
                 text: `ID: ${member.id}`,
             })
             .setTimestamp();
-        await this.wheatley.channels.welcome.send({ embeds: [embed] });
+        await this.welcome.send({ embeds: [embed] });
     }
 
     override async on_guild_member_add(member: Discord.GuildMember) {

--- a/src/components/notify-about-formerly-banned-users.ts
+++ b/src/components/notify-about-formerly-banned-users.ts
@@ -7,6 +7,7 @@ import { Wheatley } from "../wheatley.js";
 import { discord_timestamp } from "../utils/discord.js";
 import { moderation_entry } from "./moderation/schemata.js";
 import { unwrap } from "../utils/misc.js";
+import { CommandSetBuilder } from "../command-abstractions/command-set-builder.js";
 
 export default class NotifyAboutFormerlyBannedUsers extends BotComponent {
     private staff_action_log: Discord.TextChannel;
@@ -14,7 +15,7 @@ export default class NotifyAboutFormerlyBannedUsers extends BotComponent {
         moderations: moderation_entry;
     }>();
 
-    override async setup(commands: any) {
+    override async setup(commands: CommandSetBuilder) {
         this.staff_action_log = await this.utilities.get_channel(this.wheatley.channels.staff_action_log);
     }
 

--- a/src/components/notify-about-formerly-banned-users.ts
+++ b/src/components/notify-about-formerly-banned-users.ts
@@ -9,9 +9,14 @@ import { moderation_entry } from "./moderation/schemata.js";
 import { unwrap } from "../utils/misc.js";
 
 export default class NotifyAboutFormerlyBannedUsers extends BotComponent {
+    private staff_action_log: Discord.TextChannel;
     private database = this.wheatley.database.create_proxy<{
         moderations: moderation_entry;
     }>();
+
+    override async setup(commands: any) {
+        this.staff_action_log = await this.utilities.get_channel(this.wheatley.channels.staff_action_log);
+    }
 
     async alert(member: Discord.GuildMember, most_recent: moderation_entry) {
         const action = most_recent.type == "kick" ? "kicked" : "banned";
@@ -31,7 +36,7 @@ export default class NotifyAboutFormerlyBannedUsers extends BotComponent {
                 text: `ID: ${member.id}`,
             })
             .setTimestamp();
-        await this.wheatley.channels.staff_action_log.send({ embeds: [embed] });
+        await this.staff_action_log.send({ embeds: [embed] });
     }
 
     async find_most_recent_kick_or_ban(member: Discord.GuildMember) {

--- a/src/components/pin-archive.ts
+++ b/src/components/pin-archive.ts
@@ -11,6 +11,7 @@ import { TextBasedCommand } from "../command-abstractions/text-based-command.js"
 import { build_description } from "../utils/strings.js";
 import { KeyedMutexSet } from "../utils/containers.js";
 import { unwrap } from "../utils/misc.js";
+import { CommandSetBuilder } from "../command-abstractions/command-set-builder.js";
 
 // we store all pins for the server, with a flag indicating if currently in the pin list
 type pin_entry = {
@@ -40,7 +41,7 @@ export default class PinArchive extends BotComponent {
         wheatley.client.on("channelPinsUpdate", this.on_pin_update.bind(this));
     }
 
-    override async setup(commands: any) {
+    override async setup(commands: CommandSetBuilder) {
         this.pin_archive = await this.utilities.get_channel(this.wheatley.channels.pin_archive);
     }
 

--- a/src/components/pin-archive.ts
+++ b/src/components/pin-archive.ts
@@ -27,7 +27,8 @@ type pin_archive_entry = {
 };
 
 export default class PinArchive extends BotComponent {
-    mutex = new KeyedMutexSet<string>();
+    private pin_archive: Discord.TextChannel;
+    mutex = new KeyedMutexSet<string>;
 
     private database = this.wheatley.database.create_proxy<{
         pins: pin_entry;
@@ -37,6 +38,10 @@ export default class PinArchive extends BotComponent {
     constructor(wheatley: Wheatley) {
         super(wheatley);
         wheatley.client.on("channelPinsUpdate", this.on_pin_update.bind(this));
+    }
+
+    override async setup(commands: any) {
+        this.pin_archive = await this.utilities.get_channel(this.wheatley.channels.pin_archive);
     }
 
     on_pin_update(channel: Discord.TextBasedChannel, time: Date) {
@@ -57,7 +62,7 @@ export default class PinArchive extends BotComponent {
                 // edit
                 let pin_archive_message;
                 try {
-                    pin_archive_message = await this.wheatley.channels.pin_archive.messages.fetch(
+                    pin_archive_message = await this.pin_archive.messages.fetch(
                         pin_archive_entry.archive_message,
                     );
                 } catch (e: any) {
@@ -75,7 +80,7 @@ export default class PinArchive extends BotComponent {
             } else {
                 // send
                 try {
-                    const archive_message = await this.wheatley.channels.pin_archive.send({
+                    const archive_message = await this.pin_archive.send({
                         content: `<#${message.channel.id}>`,
                         ...(await make_embeds()),
                     });

--- a/src/components/pin-archive.ts
+++ b/src/components/pin-archive.ts
@@ -28,7 +28,7 @@ type pin_archive_entry = {
 
 export default class PinArchive extends BotComponent {
     private pin_archive: Discord.TextChannel;
-    mutex = new KeyedMutexSet<string>;
+    mutex = new KeyedMutexSet<string>();
 
     private database = this.wheatley.database.create_proxy<{
         pins: pin_entry;
@@ -62,9 +62,7 @@ export default class PinArchive extends BotComponent {
                 // edit
                 let pin_archive_message;
                 try {
-                    pin_archive_message = await this.pin_archive.messages.fetch(
-                        pin_archive_entry.archive_message,
-                    );
+                    pin_archive_message = await this.pin_archive.messages.fetch(pin_archive_entry.archive_message);
                 } catch (e: any) {
                     // unknown message
                     if (e instanceof Discord.DiscordAPIError && e.code === 10008) {

--- a/src/components/redirect.ts
+++ b/src/components/redirect.ts
@@ -13,9 +13,9 @@ import { format_list } from "../utils/strings.js";
 export default class Redirect extends BotComponent {
     private c_cpp_discussion: Discord.TextChannel;
     private general_discussion: Discord.TextChannel;
-    private cpp_help: Discord.TextChannel;
+    private cpp_help: Discord.ForumChannel;
     private cpp_help_text: Discord.TextChannel;
-    private c_help: Discord.TextChannel;
+    private c_help: Discord.ForumChannel;
     private c_help_text: Discord.TextChannel;
     private tooling: Discord.TextChannel;
     private algorithms_and_compsci: Discord.TextChannel;
@@ -23,9 +23,9 @@ export default class Redirect extends BotComponent {
     override async setup(commands: CommandSetBuilder) {
         this.c_cpp_discussion = await this.utilities.get_channel(this.wheatley.channels.c_cpp_discussion);
         this.general_discussion = await this.utilities.get_channel(this.wheatley.channels.general_discussion);
-        this.cpp_help = await this.utilities.get_channel(this.wheatley.channels.cpp_help);
+        this.cpp_help = await this.utilities.get_forum_channel(this.wheatley.channels.cpp_help);
         this.cpp_help_text = await this.utilities.get_channel(this.wheatley.channels.cpp_help_text);
-        this.c_help = await this.utilities.get_channel(this.wheatley.channels.c_help);
+        this.c_help = await this.utilities.get_forum_channel(this.wheatley.channels.c_help);
         this.c_help_text = await this.utilities.get_channel(this.wheatley.channels.c_help_text);
         this.tooling = await this.utilities.get_channel(this.wheatley.channels.tooling);
         this.algorithms_and_compsci = await this.utilities.get_channel(this.wheatley.channels.algorithms_and_compsci);

--- a/src/components/redirect.ts
+++ b/src/components/redirect.ts
@@ -11,7 +11,24 @@ import { TextBasedCommand } from "../command-abstractions/text-based-command.js"
 import { format_list } from "../utils/strings.js";
 
 export default class Redirect extends BotComponent {
+    private c_cpp_discussion: Discord.TextChannel;
+    private general_discussion: Discord.TextChannel;
+    private cpp_help: Discord.TextChannel;
+    private cpp_help_text: Discord.TextChannel;
+    private c_help: Discord.TextChannel;
+    private c_help_text: Discord.TextChannel;
+    private tooling: Discord.TextChannel;
+    private algorithms_and_compsci: Discord.TextChannel;
+
     override async setup(commands: CommandSetBuilder) {
+        this.c_cpp_discussion = await this.utilities.get_channel(this.wheatley.channels.c_cpp_discussion);
+        this.general_discussion = await this.utilities.get_channel(this.wheatley.channels.general_discussion);
+        this.cpp_help = await this.utilities.get_channel(this.wheatley.channels.cpp_help);
+        this.cpp_help_text = await this.utilities.get_channel(this.wheatley.channels.cpp_help_text);
+        this.c_help = await this.utilities.get_channel(this.wheatley.channels.c_help);
+        this.c_help_text = await this.utilities.get_channel(this.wheatley.channels.c_help_text);
+        this.tooling = await this.utilities.get_channel(this.wheatley.channels.tooling);
+        this.algorithms_and_compsci = await this.utilities.get_channel(this.wheatley.channels.algorithms_and_compsci);
         commands.add(
             new TextBasedCommandBuilder("redirect", EarlyReplyMode.visible)
                 .set_description("Redirect a conversation")
@@ -27,8 +44,8 @@ export default class Redirect extends BotComponent {
         commands.add(
             new TextBasedCommandBuilder("r", EarlyReplyMode.none)
                 .set_description(
-                    `Redirect a conversation from <#${this.wheatley.channels.c_cpp_discussion.id}> or ` +
-                        `<#${this.wheatley.channels.general_discussion.id}> to a help channel`,
+                    `Redirect a conversation from <#${this.c_cpp_discussion.id}> or ` +
+                        `<#${this.general_discussion.id}> to a help channel`,
                 )
                 .add_user_option({
                     title: "user",
@@ -64,18 +81,14 @@ export default class Redirect extends BotComponent {
 
     async r(command: TextBasedCommand, user: Discord.User) {
         if (
-            (
-                [
-                    "cpp_help",
-                    "cpp_help_text",
-                    "c_help",
-                    "c_help_text",
-                    "tooling",
-                    "algorithms_and_compsci",
-                ] as (keyof Wheatley["channels"])[]
-            )
-                .map(name => this.wheatley.channels[name].id)
-                .includes(command.channel_id)
+            [
+                this.cpp_help.id,
+                this.cpp_help_text.id,
+                this.c_help.id,
+                this.c_help_text.id,
+                this.tooling.id,
+                this.algorithms_and_compsci.id,
+            ].includes(command.channel_id)
         ) {
             await command.reply("Can't be used in a help channel", true);
             return;
@@ -84,13 +97,14 @@ export default class Redirect extends BotComponent {
         await command.reply({
             content:
                 `Hello <@${user.id}>, welcome to Together C & C++! This is not a help channel, please ask your ` +
-                `question in one of the help channels above (${format_list(
-                    (<(keyof Wheatley["channels"])[]>[])
-                        .concat("cpp_help", "cpp_help_text", "c_help", "c_help_text")
-                        .map(name => `<#${this.wheatley.channels[name].id}>`),
-                )}), ` +
-                `or <#${this.wheatley.channels.tooling.id}> if your question is about tooling, ` +
-                `or <#${this.wheatley.channels.algorithms_and_compsci.id}> if your question pertains more to theory, ` +
+                `question in one of the help channels above (${format_list([
+                    `<#${this.cpp_help.id}>`,
+                    `<#${this.cpp_help_text.id}>`,
+                    `<#${this.c_help.id}>`,
+                    `<#${this.c_help_text.id}>`,
+                ])}), ` +
+                `or <#${this.tooling.id}> if your question is about tooling, ` +
+                `or <#${this.algorithms_and_compsci.id}> if your question pertains more to theory, ` +
                 `or any other help channel more suited for your question.`,
             should_text_reply: false,
         });

--- a/src/components/report.ts
+++ b/src/components/report.ts
@@ -13,6 +13,7 @@ import { ModalInteractionBuilder } from "../command-abstractions/modal.js";
 import { ButtonInteractionBuilder } from "../command-abstractions/button.js";
 
 export default class Report extends BotComponent {
+    private staff_flag_log: Discord.TextChannel;
     private readonly report_modal = new Discord.ModalBuilder()
         .setCustomId("report-modal")
         .setTitle("Report Message")
@@ -48,6 +49,8 @@ export default class Report extends BotComponent {
     readonly mutex = new KeyedMutexSet<string>();
 
     override async setup(commands: CommandSetBuilder) {
+        this.staff_flag_log = await this.utilities.get_channel(this.wheatley.channels.staff_flag_log);
+
         commands.add(new MessageContextMenuInteractionBuilder("Report").set_handler(this.report.bind(this)));
 
         commands.add(new ModalInteractionBuilder(this.report_modal, this.modal_handler.bind(this)));
@@ -120,7 +123,7 @@ export default class Report extends BotComponent {
                     this.resolved,
                     this.invalid,
                 );
-                await this.wheatley.channels.staff_flag_log.send({
+                await this.staff_flag_log.send({
                     content: `<@&${this.wheatley.roles.moderators.id}>`,
                     embeds: [report_embed, ...quote_embeds.embeds],
                     components: [row],

--- a/src/components/role-manager.ts
+++ b/src/components/role-manager.ts
@@ -24,6 +24,8 @@ type user_role_entry = {
 };
 
 export default class RoleManager extends BotComponent {
+    private skill_role_log: Discord.TextChannel;
+    private staff_member_log: Discord.TextChannel;
     pink_role: Discord.Role;
     interval: NodeJS.Timeout | null = null;
 
@@ -41,6 +43,9 @@ export default class RoleManager extends BotComponent {
     }>();
 
     override async setup(commands: CommandSetBuilder) {
+        this.skill_role_log = await this.utilities.get_channel(this.wheatley.channels.skill_role_log);
+        this.staff_member_log = await this.utilities.get_channel(this.wheatley.channels.staff_member_log);
+
         commands.add(
             new TextBasedCommandBuilder("gimmepink", EarlyReplyMode.ephemeral)
                 .set_description("Gives pink")
@@ -186,7 +191,7 @@ export default class RoleManager extends BotComponent {
             }
             this.debounce_map.insert(debounce_key);
             M.log("Detected skill level increase for", new_member.user.tag);
-            await this.wheatley.channels.skill_role_log.send({
+            await this.skill_role_log.send({
                 embeds: [
                     new Discord.EmbedBuilder()
                         .setAuthor({
@@ -245,7 +250,7 @@ export default class RoleManager extends BotComponent {
         if (roles_entry === null) {
             return;
         }
-        this.wheatley.llog(this.wheatley.channels.staff_member_log, {
+        this.wheatley.llog(this.staff_member_log, {
             embeds: [
                 new Discord.EmbedBuilder()
                     .setTitle("Re-Adding roles for Member")

--- a/src/components/speedrun.ts
+++ b/src/components/speedrun.ts
@@ -57,8 +57,6 @@ export default class Speedrun extends BotComponent {
                 text: `ID: ${user.id}`,
             })
             .setTimestamp();
-        this.staff_action_log
-            .send({ embeds: [embed] })
-            .catch(this.wheatley.critical_error.bind(this.wheatley));
+        this.staff_action_log.send({ embeds: [embed] }).catch(this.wheatley.critical_error.bind(this.wheatley));
     }
 }

--- a/src/components/speedrun.ts
+++ b/src/components/speedrun.ts
@@ -6,6 +6,7 @@ import { colors } from "../common.js";
 import { BotComponent } from "../bot-component.js";
 import { Wheatley } from "../wheatley.js";
 import { discord_timestamp } from "../utils/discord.js";
+import { CommandSetBuilder } from "../command-abstractions/command-set-builder.js";
 
 export default class Speedrun extends BotComponent {
     private staff_action_log: Discord.TextChannel;
@@ -15,7 +16,7 @@ export default class Speedrun extends BotComponent {
         this.wheatley.tracker.add_submodule({ on_ban: this.on_ban.bind(this) });
     }
 
-    override async setup(commands: any) {
+    override async setup(commands: CommandSetBuilder) {
         this.staff_action_log = await this.utilities.get_channel(this.wheatley.channels.staff_action_log);
     }
 

--- a/src/components/speedrun.ts
+++ b/src/components/speedrun.ts
@@ -8,9 +8,15 @@ import { Wheatley } from "../wheatley.js";
 import { discord_timestamp } from "../utils/discord.js";
 
 export default class Speedrun extends BotComponent {
+    private staff_action_log: Discord.TextChannel;
+
     constructor(wheatley: Wheatley) {
         super(wheatley);
         this.wheatley.tracker.add_submodule({ on_ban: this.on_ban.bind(this) });
+    }
+
+    override async setup(commands: any) {
+        this.staff_action_log = await this.utilities.get_channel(this.wheatley.channels.staff_action_log);
     }
 
     on_ban(ban: Discord.GuildBan, now: number) {
@@ -51,7 +57,7 @@ export default class Speedrun extends BotComponent {
                 text: `ID: ${user.id}`,
             })
             .setTimestamp();
-        this.wheatley.channels.staff_action_log
+        this.staff_action_log
             .send({ embeds: [embed] })
             .catch(this.wheatley.critical_error.bind(this.wheatley));
     }

--- a/src/components/thread-control.ts
+++ b/src/components/thread-control.ts
@@ -9,7 +9,10 @@ import { EarlyReplyMode, TextBasedCommandBuilder } from "../command-abstractions
 import { TextBasedCommand } from "../command-abstractions/text-based-command.js";
 
 export default class ThreadControl extends BotComponent {
+    private rules: Discord.TextChannel;
+
     override async setup(commands: CommandSetBuilder) {
+        this.rules = await this.utilities.get_channel(this.wheatley.channels.rules);
         commands.add(
             new TextBasedCommandBuilder("archive", EarlyReplyMode.ephemeral)
                 .set_description("Archives the thread")
@@ -44,7 +47,7 @@ export default class ThreadControl extends BotComponent {
         const channel = await request.get_channel();
         if (channel.isThread()) {
             const thread = channel;
-            if (thread.parentId == this.wheatley.channels.rules.id) {
+            if (thread.parentId == this.rules.id) {
                 return true; // just let the user do it, should be fine
             }
             const owner_id = await this.get_owner(thread);
@@ -70,7 +73,7 @@ export default class ThreadControl extends BotComponent {
             const channel = await command.get_channel();
             assert(channel.isThread());
             if (
-                channel.parentId == this.wheatley.channels.rules.id &&
+                channel.parentId == this.rules.id &&
                 channel.type == Discord.ChannelType.PrivateThread
             ) {
                 await command.reply("Archiving", true);

--- a/src/components/thread-control.ts
+++ b/src/components/thread-control.ts
@@ -72,10 +72,7 @@ export default class ThreadControl extends BotComponent {
         if (await this.try_to_control_thread(command, "archive")) {
             const channel = await command.get_channel();
             assert(channel.isThread());
-            if (
-                channel.parentId == this.rules.id &&
-                channel.type == Discord.ChannelType.PrivateThread
-            ) {
+            if (channel.parentId == this.rules.id && channel.type == Discord.ChannelType.PrivateThread) {
                 await command.reply("Archiving", true);
                 await channel.setArchived();
             } else {

--- a/src/components/tracked-mentions.ts
+++ b/src/components/tracked-mentions.ts
@@ -10,7 +10,12 @@ import { Wheatley } from "../wheatley.js";
  * Tracks certain mentions, such as mentions of root, moderators, Wheatley, etc.
  */
 export default class TrackedMentions extends BotComponent {
+    private staff_action_log: Discord.TextChannel;
     tracked_mentions: Set<string>;
+
+    override async setup(commands: any) {
+        this.staff_action_log = await this.utilities.get_channel(this.wheatley.channels.staff_action_log);
+    }
 
     override async on_ready() {
         this.tracked_mentions = new Set([
@@ -44,7 +49,7 @@ export default class TrackedMentions extends BotComponent {
                     text: `ID: ${message.author.id}`,
                 })
                 .setTimestamp();
-            await this.wheatley.channels.staff_action_log.send({ embeds: [embed] });
+            await this.staff_action_log.send({ embeds: [embed] });
         }
     }
 

--- a/src/components/tracked-mentions.ts
+++ b/src/components/tracked-mentions.ts
@@ -5,6 +5,7 @@ import { M } from "../utils/debugging-and-logging.js";
 import { colors } from "../common.js";
 import { BotComponent } from "../bot-component.js";
 import { Wheatley } from "../wheatley.js";
+import { CommandSetBuilder } from "../command-abstractions/command-set-builder.js";
 
 /**
  * Tracks certain mentions, such as mentions of root, moderators, Wheatley, etc.
@@ -13,7 +14,7 @@ export default class TrackedMentions extends BotComponent {
     private staff_action_log: Discord.TextChannel;
     tracked_mentions: Set<string>;
 
-    override async setup(commands: any) {
+    override async setup(commands: CommandSetBuilder) {
         this.staff_action_log = await this.utilities.get_channel(this.wheatley.channels.staff_action_log);
     }
 

--- a/src/components/wiki.ts
+++ b/src/components/wiki.ts
@@ -313,6 +313,8 @@ export function parse_article(
 }
 
 export default class Wiki extends BotComponent {
+    private bot_spam: Discord.TextChannel;
+
     static override get is_freestanding() {
         return true;
     }
@@ -322,6 +324,8 @@ export default class Wiki extends BotComponent {
     substitute_refs: substitution_fun = str => str;
 
     override async setup(commands: CommandSetBuilder) {
+        this.bot_spam = await this.utilities.get_channel(this.wheatley.channels.bot_spam);
+
         const emoji_map = new Map<string, string>();
         for (const [id, emoji] of this.wheatley.guild.emojis.cache) {
             if (emoji.name) {
@@ -487,13 +491,13 @@ export default class Wiki extends BotComponent {
         if (
             !(
                 this.wheatley.freestanding ||
-                channel.id === this.wheatley.channels.bot_spam.id ||
-                (channel.isThread() && channel.parentId === this.wheatley.channels.bot_spam.id) ||
+                channel.id === this.bot_spam.id ||
+                (channel.isThread() && channel.parentId === this.bot_spam.id) ||
                 channel.isDMBased()
             )
         ) {
             await command.reply(
-                `!wiki-preview must be used in <#${this.wheatley.channels.bot_spam.id}>, a bot-spam thread, or a DM`,
+                `!wiki-preview must be used in <#${this.bot_spam.id}>, a bot-spam thread, or a DM`,
                 true,
                 true,
             );

--- a/src/modules/tccpp/components/anti-screenshot.ts
+++ b/src/modules/tccpp/components/anti-screenshot.ts
@@ -7,6 +7,7 @@ import { M } from "../../../utils/debugging-and-logging.js";
 import { colors } from "../../../common.js";
 import { BotComponent } from "../../../bot-component.js";
 import { Wheatley } from "../../../wheatley.js";
+import { CommandSetBuilder } from "../../../command-abstractions/command-set-builder.js";
 
 const DISMISS_TIME = 30 * 1000;
 
@@ -27,9 +28,10 @@ function message_might_have_code(message: string) {
 export default class AntiScreenshot extends BotComponent {
     private staff_message_log: Discord.TextChannel;
 
-    override async setup(commands: any) {
+    override async setup(commands: CommandSetBuilder) {
         this.staff_message_log = await this.utilities.get_channel(this.wheatley.channels.staff_message_log);
     }
+
     override async on_message_create(message: Discord.Message) {
         if (message.author.bot) {
             return;

--- a/src/modules/tccpp/components/anti-screenshot.ts
+++ b/src/modules/tccpp/components/anti-screenshot.ts
@@ -25,6 +25,11 @@ function message_might_have_code(message: string) {
 }
 
 export default class AntiScreenshot extends BotComponent {
+    private staff_message_log: Discord.TextChannel;
+
+    override async setup(commands: any) {
+        this.staff_message_log = await this.utilities.get_channel(this.wheatley.channels.staff_message_log);
+    }
     override async on_message_create(message: Discord.Message) {
         if (message.author.bot) {
             return;
@@ -74,7 +79,7 @@ export default class AntiScreenshot extends BotComponent {
                             name: interaction.user.tag,
                             iconURL: interaction.user.avatarURL()!,
                         });
-                    await this.wheatley.channels.staff_message_log.send({
+                    await this.staff_message_log.send({
                         content: "Anti-screenshot message dismissed",
                         embeds: [log_embed],
                     });
@@ -127,7 +132,7 @@ export default class AntiScreenshot extends BotComponent {
                     iconURL: starter_message.author.avatarURL()!,
                 })
                 .setDescription(starter_message.content || "<empty>");
-            await this.wheatley.channels.staff_message_log.send({
+            await this.staff_message_log.send({
                 content: "Anti-screenshot message sent",
                 embeds: [log_embed],
                 files: starter_message.attachments.map(a => a),

--- a/src/modules/tccpp/components/anti-self-star.ts
+++ b/src/modules/tccpp/components/anti-self-star.ts
@@ -24,7 +24,7 @@ export default class AntiSelfStar extends BotComponent {
             return;
         }
         if (
-            message.channelId == this.wheatley.channels.memes.id &&
+            message.channelId == this.wheatley.channels.memes &&
             user.id == message.author.id &&
             has_media(message)
         ) {

--- a/src/modules/tccpp/components/anti-self-star.ts
+++ b/src/modules/tccpp/components/anti-self-star.ts
@@ -23,11 +23,7 @@ export default class AntiSelfStar extends BotComponent {
         if (reaction.emoji.name !== "⭐") {
             return;
         }
-        if (
-            message.channelId == this.wheatley.channels.memes &&
-            user.id == message.author.id &&
-            has_media(message)
-        ) {
+        if (message.channelId == this.wheatley.channels.memes && user.id == message.author.id && has_media(message)) {
             await this.handle_self_star(await departialize(message));
         }
     }

--- a/src/modules/tccpp/components/autoreact.ts
+++ b/src/modules/tccpp/components/autoreact.ts
@@ -122,7 +122,7 @@ export default class Autoreact extends BotComponent {
                     this.wheatley.ignorable_error("Unable to find emoji nog4g");
                 }
             }
-            if (message.channel.id == this.wheatley.channels.introductions.id) {
+            if (message.channel.id == this.wheatley.channels.introductions) {
                 if (message.member == null) {
                     // TODO: Ping zelis?
                     M.warn("Why??", message);
@@ -132,15 +132,15 @@ export default class Autoreact extends BotComponent {
                     M.log("Waving to new user", message.author.tag, message.author.id, message.url);
                     await message.react("👋");
                 }
-            } else if (message.channel.id == this.wheatley.channels.memes.id && has_media(message)) {
+            } else if (message.channel.id == this.wheatley.channels.memes && has_media(message)) {
                 M.log("Adding star reaction", message.author.tag, message.author.id, message.url);
                 await message.react("⭐");
-            } else if (message.channel.id == this.wheatley.channels.server_suggestions.id) {
+            } else if (message.channel.id == this.wheatley.channels.server_suggestions) {
                 M.log("Adding server suggestion reactions", message.author.tag, message.author.id, message.url);
                 await message.react("👍");
                 await message.react("👎");
                 await message.react("🤷");
-            } else if (message.channel.id == this.wheatley.channels.food.id && has_media(message)) {
+            } else if (message.channel.id == this.wheatley.channels.food && has_media(message)) {
                 const reaction = message.guild!.emojis.cache.find(emoji => emoji.name === "chefskiss");
                 if (reaction !== undefined) {
                     await message.react(reaction);
@@ -152,7 +152,7 @@ export default class Autoreact extends BotComponent {
             // reaction blocked
             if (e instanceof Discord.DiscordAPIError && e.code === 90001) {
                 await message.member?.timeout(1 * MINUTE, "Thou shall not block the bot");
-                if (message.channel.id == this.wheatley.channels.server_suggestions.id) {
+                if (message.channel.id == this.wheatley.channels.server_suggestions) {
                     await message.delete();
                 }
             } else {
@@ -173,7 +173,7 @@ export default class Autoreact extends BotComponent {
         ) {
             return;
         }
-        if (new_message.channel.id == this.wheatley.channels.memes.id) {
+        if (new_message.channel.id == this.wheatley.channels.memes) {
             const bot_starred = new_message.reactions.cache.get("⭐")?.users.cache.has(this.wheatley.user.id);
             // If we haven't stared (or don't know if we've starred) and the new message has media, star
             if (!bot_starred && has_media(new_message)) {
@@ -201,7 +201,7 @@ export default class Autoreact extends BotComponent {
 
     async catch_up() {
         const TCCPP = await this.wheatley.client.guilds.fetch(this.wheatley.guild.id);
-        const introductions_channel = await TCCPP.channels.fetch(this.wheatley.channels.introductions.id);
+        const introductions_channel = await TCCPP.channels.fetch(this.wheatley.channels.introductions);
         assert(introductions_channel);
         assert(introductions_channel.type == Discord.ChannelType.GuildText);
         const messages = await introductions_channel.messages.fetch({ limit: 100, cache: false });

--- a/src/modules/tccpp/components/c-help-redirect.ts
+++ b/src/modules/tccpp/components/c-help-redirect.ts
@@ -66,8 +66,8 @@ export default class CHelpRedirect extends BotComponent {
     // use the same set for both channels, shouldn't be an issue in practice
     readonly auto_triggered_users = new SelfClearingSet<string>(1 * HOUR);
 
-    private c_help_text!: Discord.TextChannel;
-    private cpp_help_text!: Discord.TextChannel;
+    private c_help_text: Discord.TextChannel;
+    private cpp_help_text: Discord.TextChannel;
 
     override async setup(commands: CommandSetBuilder) {
         this.c_help_text = await this.utilities.get_channel(this.wheatley.channels.c_help_text);

--- a/src/modules/tccpp/components/c-help-redirect.ts
+++ b/src/modules/tccpp/components/c-help-redirect.ts
@@ -66,7 +66,13 @@ export default class CHelpRedirect extends BotComponent {
     // use the same set for both channels, shouldn't be an issue in practice
     readonly auto_triggered_users = new SelfClearingSet<string>(1 * HOUR);
 
+    private c_help_text!: Discord.TextChannel;
+    private cpp_help_text!: Discord.TextChannel;
+
     override async setup(commands: CommandSetBuilder) {
+        this.c_help_text = await this.utilities.get_channel(this.wheatley.channels.c_help_text);
+        this.cpp_help_text = await this.utilities.get_channel(this.wheatley.channels.cpp_help_text);
+
         commands.add(
             new TextBasedCommandBuilder("not-c", EarlyReplyMode.none)
                 .set_description("Mark C++ code in the C help channel")
@@ -182,22 +188,22 @@ export default class CHelpRedirect extends BotComponent {
         assert(command.channel instanceof Discord.GuildChannel);
 
         // Only allowed in #c-help-text
-        if (command.channel.id != this.wheatley.channels.c_help_text.id) {
-            await command.reply(`Can only be used in <#${this.wheatley.channels.c_help_text.id}>`, true);
+        if (command.channel.id != this.wheatley.channels.c_help_text) {
+            await command.reply(`Can only be used in <#${this.wheatley.channels.c_help_text}>`, true);
             return;
         }
 
         // For manual triggers, trust the caller and don't check the message
         // Supposedly the automatic check didn't trigger, so checking the message again would fail again
         if (user) {
-            await command.channel.send(
+            await this.c_help_text.send(
                 `<@${user.id}> Your code looks like C++ code, but this is a C channel. ` +
-                    `Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
+                    `Did you mean to post in <#${this.wheatley.channels.cpp_help_text}>?`,
             );
         } else {
-            await command.channel.send(
+            await this.c_help_text.send(
                 `This code looks like C++ code, but this is a C channel. ` +
-                    `Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
+                    `Did you mean to post in <#${this.wheatley.channels.cpp_help_text}>?`,
             );
         }
     }
@@ -207,22 +213,22 @@ export default class CHelpRedirect extends BotComponent {
         assert(command.channel instanceof Discord.GuildChannel);
 
         // Only allowed in #cpp-help-text
-        if (command.channel.id != this.wheatley.channels.cpp_help_text.id) {
-            await command.reply(`Can only be used in <#${this.wheatley.channels.cpp_help_text.id}>`, true);
+        if (command.channel.id != this.wheatley.channels.cpp_help_text) {
+            await command.reply(`Can only be used in <#${this.wheatley.channels.cpp_help_text}>`, true);
             return;
         }
 
         // For manual triggers, trust the caller and don't check the message
         // Supposedly the automatic check didn't trigger, so checking the message again would fail again
         if (user) {
-            await command.channel.send(
+            await this.cpp_help_text.send(
                 `<@${user.id}> Your code looks like C code, but this is a C++ channel. ` +
-                    `Did you mean to post in <#${this.wheatley.channels.c_help_text.id}>?`,
+                    `Did you mean to post in <#${this.wheatley.channels.c_help_text}>?`,
             );
         } else {
-            await command.channel.send(
+            await this.cpp_help_text.send(
                 `This code looks like C code, but this is a C++ channel. ` +
-                    `Did you mean to post in <#${this.wheatley.channels.c_help_text.id}>?`,
+                    `Did you mean to post in <#${this.wheatley.channels.c_help_text}>?`,
             );
         }
     }
@@ -248,20 +254,20 @@ export default class CHelpRedirect extends BotComponent {
         }
 
         // Only check messages in help-text channels
-        if (message.channel.id == this.wheatley.channels.c_help_text.id) {
+        if (message.channel.id == this.wheatley.channels.c_help_text) {
             if (this.check_message_for_cpp_code(message)) {
                 this.auto_triggered_users.insert(message.author.id);
                 await message.reply(
                     `<@${message.author.id}> Your code looks like C++ code, but this is a C channel. ` +
-                        `Did you mean to post in <#${this.wheatley.channels.cpp_help_text.id}>?`,
+                        `Did you mean to post in <#${this.wheatley.channels.cpp_help_text}>?`,
                 );
             }
-        } else if (message.channel.id == this.wheatley.channels.cpp_help_text.id) {
+        } else if (message.channel.id == this.wheatley.channels.cpp_help_text) {
             if (this.check_message_for_c_code(message)) {
                 this.auto_triggered_users.insert(message.author.id);
                 await message.reply(
                     `<@${message.author.id}> Your code looks like C code, but this is a C++ channel. ` +
-                        `Did you mean to post in <#${this.wheatley.channels.c_help_text.id}>?`,
+                        `Did you mean to post in <#${this.wheatley.channels.c_help_text}>?`,
                 );
             }
         }

--- a/src/modules/tccpp/components/days-since-last-incident.ts
+++ b/src/modules/tccpp/components/days-since-last-incident.ts
@@ -17,7 +17,7 @@ export default class DaysSinceLastIncident extends BotComponent {
     last_time = "";
     timer: NodeJS.Timeout;
 
-    private days_since_last_incident!: Discord.TextChannel;
+    private days_since_last_incident: Discord.TextChannel;
 
     private database = this.wheatley.database.create_proxy<{
         moderations: moderation_entry;
@@ -26,6 +26,12 @@ export default class DaysSinceLastIncident extends BotComponent {
     constructor(wheatley: Wheatley) {
         super(wheatley);
         this.wheatley.event_hub.on("issue_moderation", this.handle_incident.bind(this));
+    }
+
+    override async setup() {
+        this.days_since_last_incident = await this.utilities.get_channel(
+            this.wheatley.channels.days_since_last_incident,
+        );
     }
 
     make_embed(incident: incident_info) {
@@ -63,8 +69,6 @@ export default class DaysSinceLastIncident extends BotComponent {
     }
 
     override async on_ready() {
-        this.days_since_last_incident = await this.utilities.get_channel(this.wheatley.channels.days_since_last_incident);
-
         const messages = (await this.days_since_last_incident.messages.fetch()).filter(
             message => message.author.id == this.wheatley.user.id,
         );

--- a/src/modules/tccpp/components/days-since-last-incident.ts
+++ b/src/modules/tccpp/components/days-since-last-incident.ts
@@ -17,6 +17,8 @@ export default class DaysSinceLastIncident extends BotComponent {
     last_time = "";
     timer: NodeJS.Timeout;
 
+    private days_since_last_incident!: Discord.TextChannel;
+
     private database = this.wheatley.database.create_proxy<{
         moderations: moderation_entry;
     }>();
@@ -61,7 +63,9 @@ export default class DaysSinceLastIncident extends BotComponent {
     }
 
     override async on_ready() {
-        const messages = (await this.wheatley.channels.days_since_last_incident.messages.fetch()).filter(
+        this.days_since_last_incident = await this.utilities.get_channel(this.wheatley.channels.days_since_last_incident);
+
+        const messages = (await this.days_since_last_incident.messages.fetch()).filter(
             message => message.author.id == this.wheatley.user.id,
         );
         assert(messages.size <= 1);
@@ -71,7 +75,7 @@ export default class DaysSinceLastIncident extends BotComponent {
         } else {
             const info = await this.last_incident_info();
             this.last_time = info.time;
-            await this.wheatley.channels.days_since_last_incident.send({
+            await this.days_since_last_incident.send({
                 embeds: [this.make_embed(info)],
             });
         }

--- a/src/modules/tccpp/components/forum-channels.ts
+++ b/src/modules/tccpp/components/forum-channels.ts
@@ -8,6 +8,7 @@ import { BotComponent } from "../../../bot-component.js";
 import { Wheatley } from "../../../wheatley.js";
 import { clear_timeout, set_interval, set_timeout } from "../../../utils/node.js";
 import { Synopsinator } from "../../../utils/synopsis.js";
+import { CommandSetBuilder } from "../../../command-abstractions/command-set-builder.js";
 
 // TODO: Take into account thread's inactivity setting
 
@@ -51,11 +52,24 @@ export default class ForumChannels extends BotComponent {
     private general_discussion: Discord.TextChannel;
     private cpp_help: Discord.ForumChannel;
     private c_help: Discord.ForumChannel;
+    private cpp_help_text: Discord.TextChannel;
+    private c_help_text: Discord.TextChannel;
 
-    override async setup(commands: any) {
+    override async setup(commands: CommandSetBuilder) {
         this.general_discussion = await this.utilities.get_channel(this.wheatley.channels.general_discussion);
         this.cpp_help = await this.utilities.get_forum_channel(this.wheatley.channels.cpp_help);
         this.c_help = await this.utilities.get_forum_channel(this.wheatley.channels.c_help);
+        this.cpp_help_text = await this.utilities.get_channel(this.wheatley.channels.cpp_help_text);
+        this.c_help_text = await this.utilities.get_channel(this.wheatley.channels.c_help_text);
+    }
+
+    private get_corresponding_text_help_channel(thread: Discord.ThreadChannel): Discord.TextChannel {
+        if (thread.parentId === this.cpp_help.id) {
+            return this.cpp_help_text;
+        } else if (thread.parentId === this.c_help.id) {
+            return this.c_help_text;
+        }
+        throw new Error(`Thread ${thread.id} is not in a recognized help forum`);
     }
 
     async forum_cleanup() {
@@ -306,7 +320,7 @@ export default class ForumChannels extends BotComponent {
                     message,
                     `New question: ${thread.name}`,
                     true,
-                    await this.wheatley.get_corresponding_text_help_channel(thread),
+                    this.get_corresponding_text_help_channel(thread),
                 );
             } else if (
                 thread.parentId != null &&

--- a/src/modules/tccpp/components/permissions-manager.ts
+++ b/src/modules/tccpp/components/permissions-manager.ts
@@ -21,7 +21,6 @@ type category_permission_entry = {
 };
 
 type channel_permission_entry = {
-    channel: Discord.GuildChannel;
     permissions: permission_overwrites;
 };
 
@@ -31,7 +30,7 @@ export default class PermissionManager extends BotComponent {
     category_permissions: Record<string, category_permission_entry> = {};
     channel_overrides: Record<string, channel_permission_entry> = {};
 
-    async setup_permissions_map() {
+    setup_permissions_map() {
         // permission sets
         const write_permissions = [
             Discord.PermissionsBitField.Flags.SendMessages,
@@ -167,7 +166,7 @@ export default class PermissionManager extends BotComponent {
         this.add_entry(this.wheatley.categories.meta_archive, mod_only_channel);
 
         // meta overrides
-        await this.add_channel_overwrite(this.wheatley.channels.rules, {
+        this.add_channel_overwrite(this.wheatley.channels.rules, {
             [this.wheatley.guild.roles.everyone.id]: {
                 deny: [
                     Discord.PermissionsBitField.Flags.SendMessages,
@@ -183,12 +182,12 @@ export default class PermissionManager extends BotComponent {
                 ],
             },
         });
-        await this.add_channel_overwrite(this.wheatley.channels.announcements, read_only_channel);
-        await this.add_channel_overwrite(this.wheatley.channels.resources, read_only_channel);
-        await this.add_channel_overwrite(this.wheatley.channels.old_resources, read_only_channel);
-        await this.add_channel_overwrite(this.wheatley.channels.partners, read_only_channel);
-        await this.add_channel_overwrite(this.wheatley.channels.articles, read_only_channel);
-        await this.add_channel_overwrite(this.wheatley.channels.server_suggestions, {
+        this.add_channel_overwrite(this.wheatley.channels.announcements, read_only_channel);
+        this.add_channel_overwrite(this.wheatley.channels.resources, read_only_channel);
+        this.add_channel_overwrite(this.wheatley.channels.old_resources, read_only_channel);
+        this.add_channel_overwrite(this.wheatley.channels.partners, read_only_channel);
+        this.add_channel_overwrite(this.wheatley.channels.articles, read_only_channel);
+        this.add_channel_overwrite(this.wheatley.channels.server_suggestions, {
             ...default_permissions,
             [this.wheatley.guild.roles.everyone.id]: {
                 deny: [
@@ -209,7 +208,7 @@ export default class PermissionManager extends BotComponent {
                 deny: [Discord.PermissionsBitField.Flags.ViewChannel],
             },
         });
-        await this.add_channel_overwrite(this.wheatley.channels.the_button, {
+        this.add_channel_overwrite(this.wheatley.channels.the_button, {
             ...default_permissions,
             [this.wheatley.guild.roles.everyone.id]: {
                 deny: [
@@ -226,11 +225,11 @@ export default class PermissionManager extends BotComponent {
                 allow: [Discord.PermissionsBitField.Flags.ViewChannel],
             },
         };
-        await this.add_channel_overwrite(this.wheatley.channels.skill_roles_meta, jedi_council);
-        await this.add_channel_overwrite(this.wheatley.channels.skill_role_suggestions, jedi_council);
+        this.add_channel_overwrite(this.wheatley.channels.skill_roles_meta, jedi_council);
+        this.add_channel_overwrite(this.wheatley.channels.skill_role_suggestions, jedi_council);
 
         // community overrides
-        await this.add_channel_overwrite(this.wheatley.channels.polls, {
+        this.add_channel_overwrite(this.wheatley.channels.polls, {
             ...read_only_channel_no_reactions,
             [this.wheatley.roles.moderators.id]: {
                 allow: [
@@ -240,35 +239,35 @@ export default class PermissionManager extends BotComponent {
                 ],
             },
         });
-        await this.add_channel_overwrite(this.wheatley.channels.today_i_learned, {
+        this.add_channel_overwrite(this.wheatley.channels.today_i_learned, {
             ...default_permissions,
             [this.wheatley.roles.no_til.id]: muted_permissions,
         });
         // off topic overrides
-        await this.add_channel_overwrite(this.wheatley.channels.memes, {
+        this.add_channel_overwrite(this.wheatley.channels.memes, {
             ...off_topic_permissions,
             [this.wheatley.roles.no_memes.id]: no_interaction_at_all,
         });
-        await this.add_channel_overwrite(this.wheatley.channels.starboard, {
+        this.add_channel_overwrite(this.wheatley.channels.starboard, {
             ...off_topic_permissions,
             [this.wheatley.roles.no_memes.id]: no_interaction_at_all,
             ...read_only_channel,
         });
-        await this.add_channel_overwrite(this.wheatley.channels.pin_archive, {
+        this.add_channel_overwrite(this.wheatley.channels.pin_archive, {
             ...off_topic_permissions,
             ...read_only_channel,
         });
-        await this.add_channel_overwrite(this.wheatley.channels.skill_role_log, {
+        this.add_channel_overwrite(this.wheatley.channels.skill_role_log, {
             ...read_only_channel,
         });
-        await this.add_channel_overwrite(this.wheatley.channels.public_action_log, {
+        this.add_channel_overwrite(this.wheatley.channels.public_action_log, {
             ...read_only_channel_no_reactions,
         });
-        await this.add_channel_overwrite(this.wheatley.channels.serious_off_topic, {
+        this.add_channel_overwrite(this.wheatley.channels.serious_off_topic, {
             ...off_topic_permissions,
             [this.wheatley.roles.no_serious_off_topic.id]: no_interaction_at_all,
         });
-        await this.add_channel_overwrite(this.wheatley.channels.room_of_requirement, {
+        this.add_channel_overwrite(this.wheatley.channels.room_of_requirement, {
             ...off_topic_permissions,
             [this.wheatley.roles.moderators.id]: {
                 allow: [
@@ -278,7 +277,7 @@ export default class PermissionManager extends BotComponent {
                 ],
             },
         });
-        await this.add_channel_overwrite(this.wheatley.channels.boosters_only, {
+        this.add_channel_overwrite(this.wheatley.channels.boosters_only, {
             ...default_permissions,
             [this.wheatley.guild.roles.everyone.id]: {
                 deny: [Discord.PermissionsBitField.Flags.ViewChannel],
@@ -288,15 +287,15 @@ export default class PermissionManager extends BotComponent {
             },
         });
         // misc overrides
-        await this.add_channel_overwrite(this.wheatley.channels.days_since_last_incident, {
+        this.add_channel_overwrite(this.wheatley.channels.days_since_last_incident, {
             ...default_permissions,
             ...read_only_channel,
         });
-        await this.add_channel_overwrite(this.wheatley.channels.literally_1984, {
+        this.add_channel_overwrite(this.wheatley.channels.literally_1984, {
             ...default_permissions,
             ...read_only_channel,
         });
-        await this.add_channel_overwrite(this.wheatley.channels.lore, {
+        this.add_channel_overwrite(this.wheatley.channels.lore, {
             ...default_permissions,
             [this.wheatley.guild.roles.everyone.id]: {
                 deny: [Discord.PermissionsBitField.Flags.ViewChannel],
@@ -306,12 +305,12 @@ export default class PermissionManager extends BotComponent {
             },
         });
         // bot dev overrides
-        await this.add_channel_overwrite(this.wheatley.channels.bot_dev_internal, mod_only_channel);
+        this.add_channel_overwrite(this.wheatley.channels.bot_dev_internal, mod_only_channel);
         // voice overrides
-        await this.add_channel_overwrite(this.wheatley.channels.chill, member_voice_channel);
-        await this.add_channel_overwrite(this.wheatley.channels.work_3, member_voice_channel);
-        await this.add_channel_overwrite(this.wheatley.channels.work_4, member_voice_channel);
-        await this.add_channel_overwrite(this.wheatley.channels.afk, {
+        this.add_channel_overwrite(this.wheatley.channels.chill, member_voice_channel);
+        this.add_channel_overwrite(this.wheatley.channels.work_3, member_voice_channel);
+        this.add_channel_overwrite(this.wheatley.channels.work_4, member_voice_channel);
+        this.add_channel_overwrite(this.wheatley.channels.afk, {
             [this.wheatley.guild.roles.everyone.id]: {
                 deny: [
                     Discord.PermissionsBitField.Flags.Speak,
@@ -326,7 +325,7 @@ export default class PermissionManager extends BotComponent {
                 ],
             },
         });
-        await this.add_channel_overwrite(this.wheatley.channels.deans_office, {
+        this.add_channel_overwrite(this.wheatley.channels.deans_office, {
             ...voice_permissions,
             [this.wheatley.guild.roles.everyone.id]: {
                 deny: [
@@ -348,15 +347,8 @@ export default class PermissionManager extends BotComponent {
         };
     }
 
-    async add_channel_overwrite(channel: Discord.GuildChannel | string, permissions: permission_overwrites) {
-        let channel_obj: Discord.GuildChannel;
-        if (typeof channel === "string") {
-            channel_obj = (await this.wheatley.client.channels.fetch(channel)) as Discord.GuildChannel;
-        } else {
-            channel_obj = channel;
-        }
-        this.channel_overrides[channel_obj.id] = {
-            channel: channel_obj,
+    add_channel_overwrite(channel_id: string, permissions: permission_overwrites) {
+        this.channel_overrides[channel_id] = {
             permissions,
         };
     }
@@ -397,7 +389,7 @@ export default class PermissionManager extends BotComponent {
     }
 
     override async on_ready() {
-        await this.setup_permissions_map();
+        this.setup_permissions_map();
         this.set_permissions().catch(this.wheatley.critical_error.bind(this.wheatley));
         setTimeout(() => {
             this.set_permissions().catch(this.wheatley.critical_error.bind(this.wheatley));

--- a/src/modules/tccpp/components/permissions-manager.ts
+++ b/src/modules/tccpp/components/permissions-manager.ts
@@ -349,14 +349,14 @@ export default class PermissionManager extends BotComponent {
     }
 
     async add_channel_overwrite(channel: Discord.GuildChannel | string, permissions: permission_overwrites) {
-        let channelObj: Discord.GuildChannel;
-        if (typeof channel === 'string') {
-            channelObj = await this.wheatley.client.channels.fetch(channel) as Discord.GuildChannel;
+        let channel_obj: Discord.GuildChannel;
+        if (typeof channel === "string") {
+            channel_obj = (await this.wheatley.client.channels.fetch(channel)) as Discord.GuildChannel;
         } else {
-            channelObj = channel;
+            channel_obj = channel;
         }
-        this.channel_overrides[channelObj.id] = {
-            channel: channelObj,
+        this.channel_overrides[channel_obj.id] = {
+            channel: channel_obj,
             permissions,
         };
     }

--- a/src/modules/tccpp/components/permissions-manager.ts
+++ b/src/modules/tccpp/components/permissions-manager.ts
@@ -31,7 +31,7 @@ export default class PermissionManager extends BotComponent {
     category_permissions: Record<string, category_permission_entry> = {};
     channel_overrides: Record<string, channel_permission_entry> = {};
 
-    setup_permissions_map() {
+    async setup_permissions_map() {
         // permission sets
         const write_permissions = [
             Discord.PermissionsBitField.Flags.SendMessages,
@@ -167,7 +167,7 @@ export default class PermissionManager extends BotComponent {
         this.add_entry(this.wheatley.categories.meta_archive, mod_only_channel);
 
         // meta overrides
-        this.add_channel_overwrite(this.wheatley.channels.rules, {
+        await this.add_channel_overwrite(this.wheatley.channels.rules, {
             [this.wheatley.guild.roles.everyone.id]: {
                 deny: [
                     Discord.PermissionsBitField.Flags.SendMessages,
@@ -183,12 +183,12 @@ export default class PermissionManager extends BotComponent {
                 ],
             },
         });
-        this.add_channel_overwrite(this.wheatley.channels.announcements, read_only_channel);
-        this.add_channel_overwrite(this.wheatley.channels.resources, read_only_channel);
-        this.add_channel_overwrite(this.wheatley.channels.old_resources, read_only_channel);
-        this.add_channel_overwrite(this.wheatley.channels.partners, read_only_channel);
-        this.add_channel_overwrite(this.wheatley.channels.articles, read_only_channel);
-        this.add_channel_overwrite(this.wheatley.channels.server_suggestions, {
+        await this.add_channel_overwrite(this.wheatley.channels.announcements, read_only_channel);
+        await this.add_channel_overwrite(this.wheatley.channels.resources, read_only_channel);
+        await this.add_channel_overwrite(this.wheatley.channels.old_resources, read_only_channel);
+        await this.add_channel_overwrite(this.wheatley.channels.partners, read_only_channel);
+        await this.add_channel_overwrite(this.wheatley.channels.articles, read_only_channel);
+        await this.add_channel_overwrite(this.wheatley.channels.server_suggestions, {
             ...default_permissions,
             [this.wheatley.guild.roles.everyone.id]: {
                 deny: [
@@ -209,7 +209,7 @@ export default class PermissionManager extends BotComponent {
                 deny: [Discord.PermissionsBitField.Flags.ViewChannel],
             },
         });
-        this.add_channel_overwrite(this.wheatley.channels.the_button, {
+        await this.add_channel_overwrite(this.wheatley.channels.the_button, {
             ...default_permissions,
             [this.wheatley.guild.roles.everyone.id]: {
                 deny: [
@@ -226,11 +226,11 @@ export default class PermissionManager extends BotComponent {
                 allow: [Discord.PermissionsBitField.Flags.ViewChannel],
             },
         };
-        this.add_channel_overwrite(this.wheatley.channels.skill_roles_meta, jedi_council);
-        this.add_channel_overwrite(this.wheatley.channels.skill_role_suggestions, jedi_council);
+        await this.add_channel_overwrite(this.wheatley.channels.skill_roles_meta, jedi_council);
+        await this.add_channel_overwrite(this.wheatley.channels.skill_role_suggestions, jedi_council);
 
         // community overrides
-        this.add_channel_overwrite(this.wheatley.channels.polls, {
+        await this.add_channel_overwrite(this.wheatley.channels.polls, {
             ...read_only_channel_no_reactions,
             [this.wheatley.roles.moderators.id]: {
                 allow: [
@@ -240,35 +240,35 @@ export default class PermissionManager extends BotComponent {
                 ],
             },
         });
-        this.add_channel_overwrite(this.wheatley.channels.today_i_learned, {
+        await this.add_channel_overwrite(this.wheatley.channels.today_i_learned, {
             ...default_permissions,
             [this.wheatley.roles.no_til.id]: muted_permissions,
         });
         // off topic overrides
-        this.add_channel_overwrite(this.wheatley.channels.memes, {
+        await this.add_channel_overwrite(this.wheatley.channels.memes, {
             ...off_topic_permissions,
             [this.wheatley.roles.no_memes.id]: no_interaction_at_all,
         });
-        this.add_channel_overwrite(this.wheatley.channels.starboard, {
+        await this.add_channel_overwrite(this.wheatley.channels.starboard, {
             ...off_topic_permissions,
             [this.wheatley.roles.no_memes.id]: no_interaction_at_all,
             ...read_only_channel,
         });
-        this.add_channel_overwrite(this.wheatley.channels.pin_archive, {
+        await this.add_channel_overwrite(this.wheatley.channels.pin_archive, {
             ...off_topic_permissions,
             ...read_only_channel,
         });
-        this.add_channel_overwrite(this.wheatley.channels.skill_role_log, {
+        await this.add_channel_overwrite(this.wheatley.channels.skill_role_log, {
             ...read_only_channel,
         });
-        this.add_channel_overwrite(this.wheatley.channels.public_action_log, {
+        await this.add_channel_overwrite(this.wheatley.channels.public_action_log, {
             ...read_only_channel_no_reactions,
         });
-        this.add_channel_overwrite(this.wheatley.channels.serious_off_topic, {
+        await this.add_channel_overwrite(this.wheatley.channels.serious_off_topic, {
             ...off_topic_permissions,
             [this.wheatley.roles.no_serious_off_topic.id]: no_interaction_at_all,
         });
-        this.add_channel_overwrite(this.wheatley.channels.room_of_requirement, {
+        await this.add_channel_overwrite(this.wheatley.channels.room_of_requirement, {
             ...off_topic_permissions,
             [this.wheatley.roles.moderators.id]: {
                 allow: [
@@ -278,7 +278,7 @@ export default class PermissionManager extends BotComponent {
                 ],
             },
         });
-        this.add_channel_overwrite(this.wheatley.channels.boosters_only, {
+        await this.add_channel_overwrite(this.wheatley.channels.boosters_only, {
             ...default_permissions,
             [this.wheatley.guild.roles.everyone.id]: {
                 deny: [Discord.PermissionsBitField.Flags.ViewChannel],
@@ -288,15 +288,15 @@ export default class PermissionManager extends BotComponent {
             },
         });
         // misc overrides
-        this.add_channel_overwrite(this.wheatley.channels.days_since_last_incident, {
+        await this.add_channel_overwrite(this.wheatley.channels.days_since_last_incident, {
             ...default_permissions,
             ...read_only_channel,
         });
-        this.add_channel_overwrite(this.wheatley.channels.literally_1984, {
+        await this.add_channel_overwrite(this.wheatley.channels.literally_1984, {
             ...default_permissions,
             ...read_only_channel,
         });
-        this.add_channel_overwrite(this.wheatley.channels.lore, {
+        await this.add_channel_overwrite(this.wheatley.channels.lore, {
             ...default_permissions,
             [this.wheatley.guild.roles.everyone.id]: {
                 deny: [Discord.PermissionsBitField.Flags.ViewChannel],
@@ -306,12 +306,12 @@ export default class PermissionManager extends BotComponent {
             },
         });
         // bot dev overrides
-        this.add_channel_overwrite(this.wheatley.channels.bot_dev_internal, mod_only_channel);
+        await this.add_channel_overwrite(this.wheatley.channels.bot_dev_internal, mod_only_channel);
         // voice overrides
-        this.add_channel_overwrite(this.wheatley.channels.chill, member_voice_channel);
-        this.add_channel_overwrite(this.wheatley.channels.work_3, member_voice_channel);
-        this.add_channel_overwrite(this.wheatley.channels.work_4, member_voice_channel);
-        this.add_channel_overwrite(this.wheatley.channels.afk, {
+        await this.add_channel_overwrite(this.wheatley.channels.chill, member_voice_channel);
+        await this.add_channel_overwrite(this.wheatley.channels.work_3, member_voice_channel);
+        await this.add_channel_overwrite(this.wheatley.channels.work_4, member_voice_channel);
+        await this.add_channel_overwrite(this.wheatley.channels.afk, {
             [this.wheatley.guild.roles.everyone.id]: {
                 deny: [
                     Discord.PermissionsBitField.Flags.Speak,
@@ -326,7 +326,7 @@ export default class PermissionManager extends BotComponent {
                 ],
             },
         });
-        this.add_channel_overwrite(this.wheatley.channels.deans_office, {
+        await this.add_channel_overwrite(this.wheatley.channels.deans_office, {
             ...voice_permissions,
             [this.wheatley.guild.roles.everyone.id]: {
                 deny: [
@@ -348,9 +348,15 @@ export default class PermissionManager extends BotComponent {
         };
     }
 
-    add_channel_overwrite(channel: Discord.GuildChannel, permissions: permission_overwrites) {
-        this.channel_overrides[channel.id] = {
-            channel,
+    async add_channel_overwrite(channel: Discord.GuildChannel | string, permissions: permission_overwrites) {
+        let channelObj: Discord.GuildChannel;
+        if (typeof channel === 'string') {
+            channelObj = await this.wheatley.client.channels.fetch(channel) as Discord.GuildChannel;
+        } else {
+            channelObj = channel;
+        }
+        this.channel_overrides[channelObj.id] = {
+            channel: channelObj,
             permissions,
         };
     }
@@ -391,7 +397,7 @@ export default class PermissionManager extends BotComponent {
     }
 
     override async on_ready() {
-        this.setup_permissions_map();
+        await this.setup_permissions_map();
         this.set_permissions().catch(this.wheatley.critical_error.bind(this.wheatley));
         setTimeout(() => {
             this.set_permissions().catch(this.wheatley.critical_error.bind(this.wheatley));

--- a/src/modules/tccpp/components/roulette.ts
+++ b/src/modules/tccpp/components/roulette.ts
@@ -23,11 +23,15 @@ export default class Roulette extends BotComponent {
     // user id -> streak count
     readonly streaks = new SelfClearingMap<string, number>(60 * MINUTE);
 
+    private staff_member_log!: Discord.TextChannel;
+
     private database = this.wheatley.database.create_proxy<{
         roulette_leaderboard: roulette_leaderboard_entry;
     }>();
 
     override async setup(commands: CommandSetBuilder) {
+        this.staff_member_log = await this.utilities.get_channel(this.wheatley.channels.staff_member_log);
+
         commands.add(
             new TextBasedCommandBuilder("roulette", EarlyReplyMode.none)
                 .set_description("roulette")
@@ -84,8 +88,8 @@ export default class Roulette extends BotComponent {
     }
 
     async roulette(command: TextBasedCommand) {
-        if (command.channel_id != this.wheatley.channels.bot_spam.id) {
-            await command.reply(`Must be used in <#${this.wheatley.channels.bot_spam.id}>`, true);
+        if (command.channel_id != this.wheatley.channels.bot_spam) {
+            await command.reply(`Must be used in <#${this.wheatley.channels.bot_spam}>`, true);
             return;
         }
         if (this.disabled_users.has(command.user.id)) {
@@ -121,7 +125,7 @@ export default class Roulette extends BotComponent {
                     // Send bang message
                     const m = { embeds: [this.make_bang_embed(command.user)] };
                     await command.reply(m);
-                    await this.wheatley.channels.staff_member_log.send(m);
+                    await this.staff_member_log.send(m);
                     // Setup ban message
                     const ban_embed = this.make_ban_embed(command);
                     if (!ok) {
@@ -129,13 +133,13 @@ export default class Roulette extends BotComponent {
                             text: "Error: Timeout failed ",
                         });
                     }
-                    await this.wheatley.channels.staff_member_log.send({ embeds: [ban_embed] });
+                    await this.staff_member_log.send({ embeds: [ban_embed] });
                 }
             } else {
                 const m = { embeds: [this.make_click_embed(command.user)] };
                 this.streaks.set(command.user.id, (this.streaks.get(command.user.id) ?? 0) + 1);
                 await command.reply(m);
-                await this.wheatley.channels.staff_member_log.send(m);
+                await this.staff_member_log.send(m);
                 await this.update_score(command.user.id);
             }
         } else {

--- a/src/modules/tccpp/components/roulette.ts
+++ b/src/modules/tccpp/components/roulette.ts
@@ -23,7 +23,7 @@ export default class Roulette extends BotComponent {
     // user id -> streak count
     readonly streaks = new SelfClearingMap<string, number>(60 * MINUTE);
 
-    private staff_member_log!: Discord.TextChannel;
+    private staff_member_log: Discord.TextChannel;
 
     private database = this.wheatley.database.create_proxy<{
         roulette_leaderboard: roulette_leaderboard_entry;

--- a/src/modules/tccpp/components/server-suggestion-reactions.ts
+++ b/src/modules/tccpp/components/server-suggestion-reactions.ts
@@ -59,7 +59,7 @@ export default class ServerSuggestionReactions extends BotComponent {
     // 100 messages every 3 minutes, avoid ratelimits
     // runs only on restart, no rush
     async hard_catch_up() {
-        const server_suggestions_channel = this.monitored_channels.get(this.wheatley.channels.server_suggestions.id);
+        const server_suggestions_channel = this.monitored_channels.get(this.wheatley.channels.server_suggestions);
         let oldest_seen = Date.now();
         assert(server_suggestions_channel != undefined);
         while (true) {
@@ -94,8 +94,8 @@ export default class ServerSuggestionReactions extends BotComponent {
 
     override async on_ready() {
         this.monitored_channels_ids = [
-            this.wheatley.channels.server_suggestions.id,
-            this.wheatley.channels.suggestion_dashboard.id,
+            this.wheatley.channels.server_suggestions,
+            this.wheatley.channels.suggestion_dashboard,
         ];
         if (await file_exists("src/wheatley-private/config.ts")) {
             const config = "../wheatley-private/config.js";

--- a/src/modules/tccpp/components/server-suggestion-tracker.ts
+++ b/src/modules/tccpp/components/server-suggestion-tracker.ts
@@ -53,12 +53,12 @@ export default class ServerSuggestionTracker extends BotComponent {
     private server_suggestions: Discord.TextChannel;
 
     override async setup(commands: CommandSetBuilder) {
-        this.suggestion_action_log = (await this.wheatley.client.channels.fetch(
+        this.suggestion_action_log = await this.utilities.get_thread_channel(
             this.wheatley.channels.suggestion_action_log,
-        )) as Discord.ThreadChannel;
-        this.suggestion_dashboard = (await this.wheatley.client.channels.fetch(
+        );
+        this.suggestion_dashboard = await this.utilities.get_thread_channel(
             this.wheatley.channels.suggestion_dashboard,
-        )) as Discord.ThreadChannel;
+        );
         this.server_suggestions = await this.utilities.get_channel(this.wheatley.channels.server_suggestions);
         commands.add(
             new TextBasedCommandBuilder("suggestions-dashboard-count", EarlyReplyMode.visible)

--- a/src/modules/tccpp/components/skill-role-suggestion.ts
+++ b/src/modules/tccpp/components/skill-role-suggestion.ts
@@ -44,7 +44,10 @@ export default class SkillRoleSuggestion extends BotComponent {
         skill_role_threads: skill_suggestion_thread_entry;
     }>();
 
+    private skill_role_suggestions: Discord.ForumChannel;
+
     override async setup(commands: CommandSetBuilder) {
+        this.skill_role_suggestions = await this.utilities.get_forum_channel(this.wheatley.channels.skill_role_suggestions);
         commands.add(
             new UserContextMenuInteractionBuilder("Suggest Skill Role User").set_handler(
                 this.skill_suggestion.bind(this),
@@ -152,9 +155,9 @@ export default class SkillRoleSuggestion extends BotComponent {
             .toSorted((a, b) => descending(a, b, v => v[1]))
             .filter(v => v[1] !== 0);
         const suggested_levels = sorted_filtered_counts.map(([k, _]) => k);
-        const open_tag = get_tag(this.wheatley.channels.skill_role_suggestions, "Open").id;
+        const open_tag = get_tag(this.skill_role_suggestions, "Open").id;
         const role_tags = suggested_levels.map(
-            role => get_tag(this.wheatley.channels.skill_role_suggestions, capitalize(role)).id,
+            role => get_tag(this.skill_role_suggestions, capitalize(role)).id,
         );
         return {
             tags: [open_tag, ...role_tags],
@@ -178,7 +181,7 @@ export default class SkillRoleSuggestion extends BotComponent {
                 thread_closed: null,
             });
             if (entry) {
-                const thread = await this.wheatley.channels.skill_role_suggestions.threads.fetch(entry.channel_id);
+                const thread = await this.skill_role_suggestions.threads.fetch(entry.channel_id);
                 if (thread) {
                     const start = unwrap(await thread.fetchStarterMessage());
                     const { content, tags } = await this.make_thread_status(member, entry.thread_opened);
@@ -188,7 +191,7 @@ export default class SkillRoleSuggestion extends BotComponent {
                 }
             }
             const { content, tags } = await this.make_thread_status(member, suggestion_time);
-            const thread = await this.wheatley.channels.skill_role_suggestions.threads.create({
+            const thread = await this.skill_role_suggestions.threads.create({
                 name: member.displayName,
                 autoArchiveDuration: Discord.ThreadAutoArchiveDuration.OneWeek,
                 message: {

--- a/src/modules/tccpp/components/skill-role-suggestion.ts
+++ b/src/modules/tccpp/components/skill-role-suggestion.ts
@@ -47,7 +47,9 @@ export default class SkillRoleSuggestion extends BotComponent {
     private skill_role_suggestions: Discord.ForumChannel;
 
     override async setup(commands: CommandSetBuilder) {
-        this.skill_role_suggestions = await this.utilities.get_forum_channel(this.wheatley.channels.skill_role_suggestions);
+        this.skill_role_suggestions = await this.utilities.get_forum_channel(
+            this.wheatley.channels.skill_role_suggestions,
+        );
         commands.add(
             new UserContextMenuInteractionBuilder("Suggest Skill Role User").set_handler(
                 this.skill_suggestion.bind(this),
@@ -156,9 +158,7 @@ export default class SkillRoleSuggestion extends BotComponent {
             .filter(v => v[1] !== 0);
         const suggested_levels = sorted_filtered_counts.map(([k, _]) => k);
         const open_tag = get_tag(this.skill_role_suggestions, "Open").id;
-        const role_tags = suggested_levels.map(
-            role => get_tag(this.skill_role_suggestions, capitalize(role)).id,
-        );
+        const role_tags = suggested_levels.map(role => get_tag(this.skill_role_suggestions, capitalize(role)).id);
         return {
             tags: [open_tag, ...role_tags],
             content: build_description(

--- a/src/modules/tccpp/components/starboard.ts
+++ b/src/modules/tccpp/components/starboard.ts
@@ -75,6 +75,11 @@ export default class Starboard extends BotComponent {
 
     excluded_channels: Set<string>;
 
+    private starboard!: Discord.TextChannel;
+    private staff_flag_log!: Discord.TextChannel;
+    private memes!: Discord.TextChannel;
+    private cursed_code!: Discord.TextChannel;
+
     private database = this.wheatley.database.create_proxy<{
         component_state: starboard_state;
         auto_delete_threshold_notifications: auto_delete_threshold_notifications;
@@ -140,6 +145,11 @@ export default class Starboard extends BotComponent {
     }
 
     override async on_ready() {
+        this.starboard = await this.utilities.get_channel(this.wheatley.channels.starboard);
+        this.staff_flag_log = await this.utilities.get_channel(this.wheatley.channels.staff_flag_log);
+        this.memes = await this.utilities.get_channel(this.wheatley.channels.memes);
+        this.cursed_code = await this.utilities.get_channel(this.wheatley.channels.cursed_code);
+
         const state = await this.database.component_state.findOne({ id: "starboard" });
         this.delete_emojis = state?.delete_emojis ?? [];
         this.ignored_emojis = state?.ignored_emojis ?? [];
@@ -147,17 +157,17 @@ export default class Starboard extends BotComponent {
         this.repost_emojis = state?.repost_emojis ?? [];
 
         this.excluded_channels = new Set([
-            this.wheatley.channels.rules.id,
-            this.wheatley.channels.announcements.id,
-            this.wheatley.channels.server_suggestions.id,
-            this.wheatley.channels.resources.id,
-            this.wheatley.channels.the_button.id,
-            this.wheatley.channels.introductions.id,
-            this.wheatley.channels.starboard.id,
-            this.wheatley.channels.goals2024.id,
-            this.wheatley.channels.goals2025.id,
-            this.wheatley.channels.skill_role_log.id,
-            this.wheatley.channels.polls.id,
+            this.wheatley.channels.rules,
+            this.wheatley.channels.announcements,
+            this.wheatley.channels.server_suggestions,
+            this.wheatley.channels.resources,
+            this.wheatley.channels.the_button,
+            this.wheatley.channels.introductions,
+            this.wheatley.channels.starboard,
+            this.wheatley.channels.goals2024,
+            this.wheatley.channels.goals2025,
+            this.wheatley.channels.skill_role_log,
+            this.wheatley.channels.polls,
         ]);
     }
 
@@ -184,7 +194,7 @@ export default class Starboard extends BotComponent {
             return false;
         }
         if (reaction.emoji.name == "⭐") {
-            if (reaction.message.channel.id == this.wheatley.channels.memes.id) {
+            if (reaction.message.channel.id == this.wheatley.channels.memes) {
                 return reaction.count >= memes_star_threshold;
             } else {
                 return reaction.count >= star_threshold;
@@ -192,7 +202,7 @@ export default class Starboard extends BotComponent {
         } else if (
             !(this.negative_emojis.includes(reaction.emoji.name) || this.ignored_emojis.includes(reaction.emoji.name))
         ) {
-            if (reaction.message.channel.id == this.wheatley.channels.memes.id) {
+            if (reaction.message.channel.id == this.wheatley.channels.memes) {
                 return reaction.count >= memes_other_threshold;
             } else {
                 return reaction.count >= other_threshold;
@@ -220,7 +230,7 @@ export default class Starboard extends BotComponent {
                 // edit
                 let starboard_message;
                 try {
-                    starboard_message = await this.wheatley.channels.starboard.messages.fetch(
+                    starboard_message = await this.starboard.messages.fetch(
                         starboard_entry.starboard_entry,
                     );
                 } catch (e: any) {
@@ -248,7 +258,7 @@ export default class Starboard extends BotComponent {
             } else {
                 // send
                 try {
-                    const starboard_message = await this.wheatley.channels.starboard.send({
+                    const starboard_message = await this.starboard.send({
                         content: this.reactions_string(message),
                         ...(await make_embeds()),
                     });
@@ -285,7 +295,7 @@ export default class Starboard extends BotComponent {
         );
         const max_non_negative = Math.max(...non_negative_reactions.map(([_, count]) => count)); // -inf if |a|=0
         let do_delete = true;
-        if (![this.wheatley.channels.memes.id, this.wheatley.channels.cursed_code.id].includes(message.channel.id)) {
+        if (![this.wheatley.channels.memes, this.wheatley.channels.cursed_code].includes(message.channel.id)) {
             do_delete = false;
         }
         if (trigger_reaction.count <= max_non_negative) {
@@ -307,7 +317,7 @@ export default class Starboard extends BotComponent {
                 do_delete ||
                 !(await this.database.auto_delete_threshold_notifications.findOne({ message: message.id }))
             ) {
-                flag_message = await this.wheatley.channels.staff_flag_log.send({
+                flag_message = await this.staff_flag_log.send({
                     content:
                         `${action} message from <@${message.author.id}> for ` +
                         `${trigger_reaction.count} ${trigger_reaction.emoji.name} reactions` +
@@ -345,25 +355,32 @@ export default class Starboard extends BotComponent {
             await message.delete();
             assert(!(message.channel instanceof Discord.PartialGroupDMChannel));
             if (trigger_type == delete_trigger_type.delete_this) {
-                if (message.channel.id == this.wheatley.channels.memes.id) {
-                    await message.channel.send(
+                if (message.channel.id == this.wheatley.channels.memes) {
+                    await this.memes.send(
                         `<@${message.author.id}> A message of yours was automatically deleted because a threshold for` +
                             " <:delet_this:669598943117836312> reactions (or similar) was reached.\n\n" +
                             "FAQ: How can I avoid this in the future?\n" +
                             "Answer: Post less cringe",
                     );
                 } else {
-                    await message.channel.send(
+                    await this.cursed_code.send(
                         `<@${message.author.id}> A message of yours was automatically deleted because a threshold for` +
                             " <:delet_this:669598943117836312> reactions (or similar) was reached.\n" +
                             "This was likely due to your post not actually being cursed code.",
                     );
                 }
             } else {
-                await message.channel.send(
-                    `<@${message.author.id}> A message of yours was automatically deleted because a threshold for` +
-                        " :recycle: reactions (or similar) was reached.",
-                );
+                if (message.channel.id == this.wheatley.channels.memes) {
+                    await this.memes.send(
+                        `<@${message.author.id}> A message of yours was automatically deleted because a threshold for` +
+                            " :recycle: reactions (or similar) was reached.",
+                    );
+                } else {
+                    await this.cursed_code.send(
+                        `<@${message.author.id}> A message of yours was automatically deleted because a threshold for` +
+                            " :recycle: reactions (or similar) was reached.",
+                    );
+                }
             }
             this.deletes.push(Date.now());
         }
@@ -372,7 +389,7 @@ export default class Starboard extends BotComponent {
     // Check if the # of reactions is full, and there is no negative emojis reacted yet
     should_delete_reaction(reaction: Discord.MessageReaction) {
         return (
-            reaction.message.channel.id === this.wheatley.channels.memes.id &&
+            reaction.message.channel.id === this.wheatley.channels.memes &&
             reaction.message.reactions.cache.size === 20 &&
             reaction.message.reactions.cache.filter(
                 reaction =>
@@ -462,7 +479,7 @@ export default class Starboard extends BotComponent {
         if (entry) {
             await this.mutex.lock(message.id);
             try {
-                await this.wheatley.channels.starboard.messages.delete(entry.starboard_entry);
+                await this.starboard.messages.delete(entry.starboard_entry);
                 await this.database.starboard_entries.deleteOne({ message: message.id });
             } finally {
                 this.mutex.unlock(message.id);

--- a/src/modules/tccpp/components/starboard.ts
+++ b/src/modules/tccpp/components/starboard.ts
@@ -75,10 +75,10 @@ export default class Starboard extends BotComponent {
 
     excluded_channels: Set<string>;
 
-    private starboard!: Discord.TextChannel;
-    private staff_flag_log!: Discord.TextChannel;
-    private memes!: Discord.TextChannel;
-    private cursed_code!: Discord.TextChannel;
+    private starboard: Discord.TextChannel;
+    private staff_flag_log: Discord.TextChannel;
+    private memes: Discord.TextChannel;
+    private cursed_code: Discord.TextChannel;
 
     private database = this.wheatley.database.create_proxy<{
         component_state: starboard_state;
@@ -88,6 +88,11 @@ export default class Starboard extends BotComponent {
     }>();
 
     override async setup(commands: CommandSetBuilder) {
+        this.starboard = await this.utilities.get_channel(this.wheatley.channels.starboard);
+        this.staff_flag_log = await this.utilities.get_channel(this.wheatley.channels.staff_flag_log);
+        this.memes = await this.utilities.get_channel(this.wheatley.channels.memes);
+        this.cursed_code = await this.utilities.get_channel(this.wheatley.channels.cursed_code);
+
         commands.add(
             new TextBasedCommandBuilder("add-negative-emoji", EarlyReplyMode.visible)
                 .set_description("Register a negative emoji")
@@ -145,11 +150,6 @@ export default class Starboard extends BotComponent {
     }
 
     override async on_ready() {
-        this.starboard = await this.utilities.get_channel(this.wheatley.channels.starboard);
-        this.staff_flag_log = await this.utilities.get_channel(this.wheatley.channels.staff_flag_log);
-        this.memes = await this.utilities.get_channel(this.wheatley.channels.memes);
-        this.cursed_code = await this.utilities.get_channel(this.wheatley.channels.cursed_code);
-
         const state = await this.database.component_state.findOne({ id: "starboard" });
         this.delete_emojis = state?.delete_emojis ?? [];
         this.ignored_emojis = state?.ignored_emojis ?? [];
@@ -230,9 +230,7 @@ export default class Starboard extends BotComponent {
                 // edit
                 let starboard_message;
                 try {
-                    starboard_message = await this.starboard.messages.fetch(
-                        starboard_entry.starboard_entry,
-                    );
+                    starboard_message = await this.starboard.messages.fetch(starboard_entry.starboard_entry);
                 } catch (e: any) {
                     // unknown message
                     if (e instanceof Discord.DiscordAPIError && e.code === 10008) {

--- a/src/modules/tccpp/components/starboard.ts
+++ b/src/modules/tccpp/components/starboard.ts
@@ -354,31 +354,24 @@ export default class Starboard extends BotComponent {
             assert(!(message.channel instanceof Discord.PartialGroupDMChannel));
             if (trigger_type == delete_trigger_type.delete_this) {
                 if (message.channel.id == this.wheatley.channels.memes) {
-                    await this.memes.send(
+                    await message.channel.send(
                         `<@${message.author.id}> A message of yours was automatically deleted because a threshold for` +
                             " <:delet_this:669598943117836312> reactions (or similar) was reached.\n\n" +
                             "FAQ: How can I avoid this in the future?\n" +
                             "Answer: Post less cringe",
                     );
                 } else {
-                    await this.cursed_code.send(
+                    await message.channel.send(
                         `<@${message.author.id}> A message of yours was automatically deleted because a threshold for` +
                             " <:delet_this:669598943117836312> reactions (or similar) was reached.\n" +
                             "This was likely due to your post not actually being cursed code.",
                     );
                 }
             } else {
-                if (message.channel.id == this.wheatley.channels.memes) {
-                    await this.memes.send(
-                        `<@${message.author.id}> A message of yours was automatically deleted because a threshold for` +
-                            " :recycle: reactions (or similar) was reached.",
-                    );
-                } else {
-                    await this.cursed_code.send(
-                        `<@${message.author.id}> A message of yours was automatically deleted because a threshold for` +
-                            " :recycle: reactions (or similar) was reached.",
-                    );
-                }
+                await message.channel.send(
+                    `<@${message.author.id}> A message of yours was automatically deleted because a threshold for` +
+                        " :recycle: reactions (or similar) was reached.",
+                );
             }
             this.deletes.push(Date.now());
         }

--- a/src/modules/tccpp/components/the-button.ts
+++ b/src/modules/tccpp/components/the-button.ts
@@ -70,7 +70,7 @@ export default class TheButton extends BotComponent {
     last_reset: number;
     longest_time_without_reset: number;
 
-    private the_button_channel!: Discord.TextChannel;
+    private the_button_channel: Discord.TextChannel;
 
     private database = this.wheatley.database.create_proxy<{
         component_state: the_button_state;
@@ -78,6 +78,8 @@ export default class TheButton extends BotComponent {
     }>();
 
     override async setup(commands: CommandSetBuilder) {
+        this.the_button_channel = await this.utilities.get_channel(this.wheatley.channels.the_button);
+
         commands.add(
             new TextBasedCommandBuilder("wsetupthebutton", EarlyReplyMode.none)
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
@@ -193,8 +195,6 @@ export default class TheButton extends BotComponent {
     }
 
     override async on_ready() {
-        this.the_button_channel = await this.utilities.get_channel(this.wheatley.channels.the_button);
-
         const state = await this.database.component_state.findOne({ id: "the_button" });
         this.button_presses = state?.button_presses ?? 0;
         this.last_reset = state?.last_reset ?? Date.now();

--- a/src/modules/tccpp/components/the-button.ts
+++ b/src/modules/tccpp/components/the-button.ts
@@ -70,6 +70,8 @@ export default class TheButton extends BotComponent {
     last_reset: number;
     longest_time_without_reset: number;
 
+    private the_button_channel!: Discord.TextChannel;
+
     private database = this.wheatley.database.create_proxy<{
         component_state: the_button_state;
         button_scoreboard: the_button_scoreboard_entry;
@@ -191,12 +193,14 @@ export default class TheButton extends BotComponent {
     }
 
     override async on_ready() {
+        this.the_button_channel = await this.utilities.get_channel(this.wheatley.channels.the_button);
+
         const state = await this.database.component_state.findOne({ id: "the_button" });
         this.button_presses = state?.button_presses ?? 0;
         this.last_reset = state?.last_reset ?? Date.now();
         this.longest_time_without_reset = state?.longest_time_without_reset ?? 0;
 
-        this.button_message = await this.wheatley.channels.the_button.messages.fetch(this.button_message_id);
+        this.button_message = await this.the_button_channel.messages.fetch(this.button_message_id);
         let waiting = false;
         this.interval = set_interval(() => {
             if (

--- a/src/modules/tccpp/components/thread-based-channels.ts
+++ b/src/modules/tccpp/components/thread-based-channels.ts
@@ -36,9 +36,9 @@ export default class ThreadBasedChannels extends BotComponent {
 
     override async on_ready() {
         this.thread_based_channel_ids = new Set([
-            this.wheatley.channels.server_suggestions.id,
-            this.wheatley.channels.showcase.id,
-            this.wheatley.channels.today_i_learned.id,
+            this.wheatley.channels.server_suggestions,
+            this.wheatley.channels.showcase,
+            this.wheatley.channels.today_i_learned,
         ]);
     }
 
@@ -84,7 +84,7 @@ export default class ThreadBasedChannels extends BotComponent {
     }
 
     override async on_message_delete(message: Discord.Message | Discord.PartialMessage) {
-        if (message.channelId === this.wheatley.channels.today_i_learned.id) {
+        if (message.channelId === this.wheatley.channels.today_i_learned) {
             if (message.hasThread) {
                 await unwrap(message.thread).send(
                     "This today I learned post was removed. If it was removed by a moderator it was likely due to it " +

--- a/src/wheatley.ts
+++ b/src/wheatley.ts
@@ -69,78 +69,77 @@ export type wheatley_config = core_config & {
     [key: string]: any;
 };
 
-const tuple = <T extends any[]>(...args: T): T => args;
 
-const channels_map = {
+const channels = {
     // staff
-    staff_flag_log: tuple("1026972603019169842", Discord.TextChannel),
-    staff_experimental_log: tuple("1207899185790197760", Discord.TextChannel),
-    staff_action_log: tuple("845290775692443699", Discord.TextChannel),
-    public_action_log: tuple("1341611685223596103", Discord.TextChannel),
-    staff_clock_log: tuple("1220882759862452284", Discord.ForumChannel),
-    welcome: tuple("778017793567490078", Discord.TextChannel),
-    staff_member_log: tuple("875681819662622730", Discord.TextChannel),
-    staff_message_log: tuple("467729928956411914", Discord.TextChannel),
-    staff_only: tuple("342153262260289537", Discord.TextChannel),
-    mods: tuple("847993258600038460", Discord.TextChannel),
-    voice_hotline: tuple("1379456835634987098", Discord.TextChannel),
+    staff_flag_log: "1026972603019169842",
+    staff_experimental_log: "1207899185790197760",
+    staff_action_log: "845290775692443699",
+    public_action_log: "1341611685223596103",
+    staff_clock_log: "1220882759862452284",
+    welcome: "778017793567490078",
+    staff_member_log: "875681819662622730",
+    staff_message_log: "467729928956411914",
+    staff_only: "342153262260289537",
+    mods: "847993258600038460",
+    voice_hotline: "1379456835634987098",
     // meta
-    rules: tuple("659868782877212723", Discord.TextChannel),
-    announcements: tuple("331881381477089282", Discord.NewsChannel),
-    server_suggestions: tuple("802541516655951892", Discord.TextChannel),
-    skill_role_suggestions: tuple("1211089633547526204", Discord.ForumChannel),
-    skill_roles_meta: tuple("1182536717056618557", Discord.TextChannel),
-    news: tuple("1269506410530738267", Discord.ForumChannel),
-    old_resources: tuple("1124619767542718524", Discord.ForumChannel),
-    resources: tuple("1361574878561570926", Discord.TextChannel),
-    partners: tuple("904790565000986745", Discord.TextChannel),
-    the_button: tuple("1069678919667687455", Discord.TextChannel),
-    articles: tuple("1130174377539940475", Discord.TextChannel),
+    rules: "659868782877212723",
+    announcements: "331881381477089282",
+    server_suggestions: "802541516655951892",
+    skill_role_suggestions: "1211089633547526204",
+    skill_roles_meta: "1182536717056618557",
+    news: "1269506410530738267",
+    old_resources: "1124619767542718524",
+    resources: "1361574878561570926",
+    partners: "904790565000986745",
+    the_button: "1069678919667687455",
+    articles: "1130174377539940475",
     // language channels
-    cpp_help: tuple("1013107104678162544", Discord.ForumChannel),
-    c_help: tuple("1013104018739974194", Discord.ForumChannel),
-    cpp_help_text: tuple("331718580070645760", Discord.TextChannel),
-    c_help_text: tuple("331718539738087426", Discord.TextChannel),
-    c_cpp_discussion: tuple("851121440425639956", Discord.TextChannel),
-    general_discussion: tuple("855220264149057556", Discord.TextChannel),
-    code_review: tuple("1078717238678409369", Discord.ForumChannel),
-    showcase: tuple("1014328785685979136", Discord.ForumChannel),
-    tooling: tuple("331913460080181258", Discord.TextChannel),
-    algorithms_and_compsci: tuple("857668280012242944", Discord.TextChannel),
+    cpp_help: "1013107104678162544",
+    c_help: "1013104018739974194",
+    cpp_help_text: "331718580070645760",
+    c_help_text: "331718539738087426",
+    c_cpp_discussion: "851121440425639956",
+    general_discussion: "855220264149057556",
+    code_review: "1078717238678409369",
+    showcase: "1014328785685979136",
+    tooling: "331913460080181258",
+    algorithms_and_compsci: "857668280012242944",
     // off-topic
-    starboard: tuple("800509841424252968", Discord.TextChannel),
-    memes: tuple("526518219549442071", Discord.TextChannel),
-    food: tuple("1288515484513468436", Discord.TextChannel),
-    serious_off_topic: tuple("921113903574958080", Discord.TextChannel),
-    room_of_requirement: tuple("1082800064113672192", Discord.TextChannel),
-    boosters_only: tuple("792183875241639977", Discord.TextChannel),
+    starboard: "800509841424252968",
+    memes: "526518219549442071",
+    food: "1288515484513468436",
+    serious_off_topic: "921113903574958080",
+    room_of_requirement: "1082800064113672192",
+    boosters_only: "792183875241639977",
     // other
-    bot_spam: tuple("506274405500977153", Discord.TextChannel),
-    introductions: tuple("933113495304679494", Discord.TextChannel),
-    cursed_code: tuple("855220292736516128", Discord.TextChannel),
-    suggestion_dashboard: tuple("908928083879415839", Discord.ThreadChannel),
-    suggestion_action_log: tuple("909309608512880681", Discord.ThreadChannel),
-    today_i_learned: tuple("873682069325217802", Discord.TextChannel),
-    goals2024: tuple("1189255286364569640", Discord.TextChannel),
-    goals2025: tuple("1323734788707848253", Discord.TextChannel),
-    days_since_last_incident: tuple("1195920462958575676", Discord.TextChannel),
-    literally_1984: tuple("1097993854214488154", Discord.TextChannel),
-    lore: tuple("890067781628866620", Discord.TextChannel),
-    bot_dev_internal: tuple("1166517065763536977", Discord.TextChannel),
-    pin_archive: tuple("1284234644396572714", Discord.TextChannel),
-    skill_role_log: tuple("1315023714206617610", Discord.TextChannel),
-    polls: tuple("1319336135213846568", Discord.NewsChannel),
-    wiki_dev: tuple("1350899338229846127", Discord.TextChannel),
+    bot_spam: "506274405500977153",
+    introductions: "933113495304679494",
+    cursed_code: "855220292736516128",
+    suggestion_dashboard: "908928083879415839",
+    suggestion_action_log: "909309608512880681",
+    today_i_learned: "873682069325217802",
+    goals2024: "1189255286364569640",
+    goals2025: "1323734788707848253",
+    days_since_last_incident: "1195920462958575676",
+    literally_1984: "1097993854214488154",
+    lore: "890067781628866620",
+    bot_dev_internal: "1166517065763536977",
+    pin_archive: "1284234644396572714",
+    skill_role_log: "1315023714206617610",
+    polls: "1319336135213846568",
+    wiki_dev: "1350899338229846127",
     // voice
-    chill: tuple("1358502332941467879", Discord.VoiceChannel),
-    work_3: tuple("1358502770575147230", Discord.VoiceChannel),
-    work_4: tuple("1367735453112864838", Discord.VoiceChannel),
-    afk: tuple("331732845523369985", Discord.VoiceChannel),
-    deans_office: tuple("1379612678649155755", Discord.VoiceChannel),
+    chill: "1358502332941467879",
+    work_3: "1358502770575147230",
+    work_4: "1367735453112864838",
+    afk: "331732845523369985",
+    deans_office: "1379612678649155755",
     // red telephone
-    red_telephone_alerts: tuple("1140096352278290512", Discord.TextChannel),
+    red_telephone_alerts: "1140096352278290512",
     // error log
-    log: tuple("1260777903700971581", Discord.TextChannel),
+    log: "1260777903700971581",
 };
 
 const categories_map = {
@@ -281,11 +280,7 @@ export class Wheatley {
 
     private log_channel: Discord.TextBasedChannel | null = null;
 
-    readonly channels: {
-        // ["prototype"] gets the instance type, eliminating the `typeof`. InstanceType<T> doesn't work for a protected
-        // constructor, weirdly.
-        [k in keyof typeof channels_map]: (typeof channels_map)[k][1]["prototype"];
-    } = {} as any;
+    readonly channels = channels;
 
     readonly categories: {
         [k in keyof typeof categories_map]: Discord.CategoryChannel;
@@ -377,7 +372,7 @@ export class Wheatley {
             (async () => {
                 // Fetch the log channel immediately
                 if (!config.freestanding) {
-                    const channel = await this.client.channels.fetch(channels_map.log[0]);
+                    const channel = await this.client.channels.fetch(channels.log);
                     this.log_channel = channel && channel.isTextBased() ? channel : null;
                 }
 
@@ -453,19 +448,6 @@ export class Wheatley {
                 return value as T;
             }
         };
-        // Channels
-        await Promise.all(
-            Object.entries(channels_map).map(async ([k, [id, type]]) => {
-                const channel = await wrap(() => this.client.channels.fetch(id));
-                if (this.freestanding && channel === null) {
-                    return;
-                }
-                assert(channel !== null, `Channel ${k} ${id} not found`);
-                assert(channel instanceof type, `Channel ${k} ${id} not of the expected type`);
-                this.channels[k as keyof typeof channels_map] = channel as any;
-                M.log(`Fetched channel ${k}`);
-            }),
-        );
         // Categories
         await Promise.all(
             Object.entries(categories_map).map(async ([k, id]) => {
@@ -630,18 +612,18 @@ export class Wheatley {
     }
 
     is_forum_help_channel(id: string) {
-        return [this.channels.cpp_help.id, this.channels.c_help.id].includes(id);
+        return [this.channels.cpp_help, this.channels.c_help].includes(id);
     }
 
     is_forum_help_thread(thread: Discord.ThreadChannel) {
         return thread.parentId != null && this.is_forum_help_channel(thread.parentId);
     }
 
-    get_corresponding_text_help_channel(thread: Discord.ThreadChannel) {
-        if (thread.parentId == this.channels.cpp_help.id) {
-            return this.channels.cpp_help_text;
-        } else if (thread.parentId == this.channels.c_help.id) {
-            return this.channels.c_help_text;
+    async get_corresponding_text_help_channel(thread: Discord.ThreadChannel) {
+        if (thread.parentId == this.channels.cpp_help) {
+            return await this.client.channels.fetch(this.channels.cpp_help_text) as Discord.TextChannel;
+        } else if (thread.parentId == this.channels.c_help) {
+            return await this.client.channels.fetch(this.channels.c_help_text) as Discord.TextChannel;
         }
         assert(false);
     }

--- a/src/wheatley.ts
+++ b/src/wheatley.ts
@@ -69,7 +69,6 @@ export type wheatley_config = core_config & {
     [key: string]: any;
 };
 
-
 const channels = {
     // staff
     staff_flag_log: "1026972603019169842",
@@ -621,9 +620,9 @@ export class Wheatley {
 
     async get_corresponding_text_help_channel(thread: Discord.ThreadChannel) {
         if (thread.parentId == this.channels.cpp_help) {
-            return await this.client.channels.fetch(this.channels.cpp_help_text) as Discord.TextChannel;
+            return (await this.client.channels.fetch(this.channels.cpp_help_text)) as Discord.TextChannel;
         } else if (thread.parentId == this.channels.c_help) {
-            return await this.client.channels.fetch(this.channels.c_help_text) as Discord.TextChannel;
+            return (await this.client.channels.fetch(this.channels.c_help_text)) as Discord.TextChannel;
         }
         assert(false);
     }

--- a/src/wheatley.ts
+++ b/src/wheatley.ts
@@ -618,15 +618,6 @@ export class Wheatley {
         return thread.parentId != null && this.is_forum_help_channel(thread.parentId);
     }
 
-    async get_corresponding_text_help_channel(thread: Discord.ThreadChannel) {
-        if (thread.parentId == this.channels.cpp_help) {
-            return (await this.client.channels.fetch(this.channels.cpp_help_text)) as Discord.TextChannel;
-        } else if (thread.parentId == this.channels.c_help) {
-            return (await this.client.channels.fetch(this.channels.c_help_text)) as Discord.TextChannel;
-        }
-        assert(false);
-    }
-
     // utility: returns the channel for regular channels or the thread / forum post parent
     top_level_channel(channel: Discord.TextBasedChannel) {
         if (channel instanceof Discord.ThreadChannel && channel.parentId != null) {


### PR DESCRIPTION
Instead of having a massive map of channels in wheatley, which was convenient but not very conducive to running the bot elsewhere, it's more principled to have every module just fetch their own channels as part of startup. This PR implements that. These changes were also mostly done by claude.

This also fixes the horrible typescript errors that manifested in 58d6ef708e74f7d6f503206d33fbea5fec422ed8 where a mundane change in an unrelated part of the codebase resulted in errors about union sizes, caused because of the massive channel type in wheatley.

Twin PR: https://github.com/TCCPP/wheatley-private/pull/15