### PR TITLE
Rework help command generation

### DIFF
--- a/src/command-abstractions/text-based-command-builder.ts
+++ b/src/command-abstractions/text-based-command-builder.ts
@@ -21,6 +21,15 @@ export type TextBasedCommandParameterOptions = {
     autocomplete?: (partial: string, command_name: string) => { name: string; value: string }[];
 };
 
+export type CommandCategory =
+    | "Wiki Articles"
+    | "References"
+    | "Thread Control"
+    | "Utility"
+    | "Misc"
+    | "Moderation"
+    | "Moderation Utilities";
+
 export enum EarlyReplyMode {
     ephemeral,
     visible,
@@ -39,13 +48,15 @@ export class TextBasedCommandBuilder<
     options = new Discord.Collection<string, TextBasedCommandParameterOptions & { type: TextBasedCommandOptionType }>();
     slash_config: boolean[];
     permissions: undefined | bigint = undefined;
+    category: CommandCategory;
     subcommands: TextBasedCommandBuilder<any, true, true>[] = [];
     type: HasSubcommands extends true ? "top-level" : "default";
     allow_trailing_junk: boolean = false;
 
-    constructor(names: string | MoreThanOne<string>, early_reply_mode: EarlyReplyMode) {
+    constructor(names: string | MoreThanOne<string>, category: CommandCategory, early_reply_mode: EarlyReplyMode) {
         super();
         this.names = Array.isArray(names) ? names : [names];
+        this.category = category;
         this.early_reply_mode = early_reply_mode;
         this.slash_config = new Array(this.names.length).fill(true);
         this.type = "default" as any;
@@ -249,6 +260,7 @@ export class TextBasedCommandBuilder<
                     description,
                     slash,
                     this.permissions,
+                    this.category,
                     this.allow_trailing_junk,
                     this.early_reply_mode,
                     this,

--- a/src/command-abstractions/text-based-command-builder.ts
+++ b/src/command-abstractions/text-based-command-builder.ts
@@ -23,13 +23,11 @@ export type TextBasedCommandParameterOptions = {
 
 export type CommandCategory =
     | "Wiki Articles"
-    | "Wiki Shortcuts"
     | "References"
     | "Thread Control"
     | "Utility"
     | "Misc"
     | "Moderation"
-    | "Rolepersist Shortcuts"
     | "Moderation Utilities"
     | "Admin utilities"
     | "Hidden";

--- a/src/command-abstractions/text-based-command-builder.ts
+++ b/src/command-abstractions/text-based-command-builder.ts
@@ -51,16 +51,15 @@ export class TextBasedCommandBuilder<
     descriptions!: ConditionalOptional<HasDescriptions, string[]>;
     options = new Discord.Collection<string, TextBasedCommandParameterOptions & { type: TextBasedCommandOptionType }>();
     slash_config: boolean[];
-    permissions: undefined | bigint = undefined;
-    category: CommandCategory;
+    permissions: bigint | undefined = undefined;
+    category: CommandCategory | undefined = undefined;
     subcommands: TextBasedCommandBuilder<any, true, true>[] = [];
     type: HasSubcommands extends true ? "top-level" : "default";
     allow_trailing_junk: boolean = false;
 
-    constructor(names: string | MoreThanOne<string>, category: CommandCategory, early_reply_mode: EarlyReplyMode) {
+    constructor(names: string | MoreThanOne<string>, early_reply_mode: EarlyReplyMode) {
         super();
         this.names = Array.isArray(names) ? names : [names];
-        this.category = category;
         this.early_reply_mode = early_reply_mode;
         this.slash_config = new Array(this.names.length).fill(true);
         this.type = "default" as any;
@@ -224,6 +223,11 @@ export class TextBasedCommandBuilder<
 
     set_permissions(permissions: bigint) {
         this.permissions = permissions;
+        return this;
+    }
+
+    set_category(category: CommandCategory) {
+        this.category = category;
         return this;
     }
 

--- a/src/command-abstractions/text-based-command-builder.ts
+++ b/src/command-abstractions/text-based-command-builder.ts
@@ -53,6 +53,7 @@ export class TextBasedCommandBuilder<
     slash_config: boolean[];
     permissions: bigint | undefined = undefined;
     category: CommandCategory | undefined = undefined;
+    alias_of: string | undefined = undefined;
     subcommands: TextBasedCommandBuilder<any, true, true>[] = [];
     type: HasSubcommands extends true ? "top-level" : "default";
     allow_trailing_junk: boolean = false;
@@ -231,6 +232,11 @@ export class TextBasedCommandBuilder<
         return this;
     }
 
+    set_alias_of(command_name: string) {
+        this.alias_of = command_name;
+        return this;
+    }
+
     set_allow_trailing_junk(allow_trailing_junk: boolean) {
         this.allow_trailing_junk = allow_trailing_junk;
         return this;
@@ -264,11 +270,12 @@ export class TextBasedCommandBuilder<
             descriptors.push(
                 new BotTextBasedCommand(
                     name,
-                    name,
+                    "",
                     description,
                     slash,
                     this.permissions,
                     this.category,
+                    this.alias_of,
                     this.allow_trailing_junk,
                     this.early_reply_mode,
                     this,

--- a/src/command-abstractions/text-based-command-builder.ts
+++ b/src/command-abstractions/text-based-command-builder.ts
@@ -23,13 +23,16 @@ export type TextBasedCommandParameterOptions = {
 
 export type CommandCategory =
     | "Wiki Articles"
+    | "Wiki Shortcuts"
     | "References"
     | "Thread Control"
     | "Utility"
     | "Misc"
     | "Moderation"
+    | "Rolepersist Shortcuts"
     | "Moderation Utilities"
-    | "Admin utilities";
+    | "Admin utilities"
+    | "Hidden";
 
 export enum EarlyReplyMode {
     ephemeral,

--- a/src/command-abstractions/text-based-command-builder.ts
+++ b/src/command-abstractions/text-based-command-builder.ts
@@ -28,7 +28,8 @@ export type CommandCategory =
     | "Utility"
     | "Misc"
     | "Moderation"
-    | "Moderation Utilities";
+    | "Moderation Utilities"
+    | "Admin utilities";
 
 export enum EarlyReplyMode {
     ephemeral,

--- a/src/command-abstractions/text-based-command-descriptor.ts
+++ b/src/command-abstractions/text-based-command-descriptor.ts
@@ -11,6 +11,7 @@ import {
     TextBasedCommandOptionType,
     TextBasedCommandBuilder,
     EarlyReplyMode,
+    CommandCategory,
 } from "./text-based-command-builder.js";
 import { TextBasedCommand } from "./text-based-command.js";
 import { BaseBotInteraction } from "./interaction-base.js";
@@ -30,6 +31,7 @@ export class BotTextBasedCommand<Args extends unknown[] = []> extends BaseBotInt
         public readonly description: string,
         public readonly slash: boolean,
         public readonly permissions: undefined | bigint,
+        public readonly category: CommandCategory,
         public readonly allow_trailing_junk: boolean,
         public readonly early_reply_mode: EarlyReplyMode,
         builder: TextBasedCommandBuilder<Args, true, true> | TextBasedCommandBuilder<Args, true, false, true>,
@@ -54,6 +56,7 @@ export class BotTextBasedCommand<Args extends unknown[] = []> extends BaseBotInt
                             sub_description,
                             sub_slash,
                             permissions,
+                            category,
                             allow_trailing_junk,
                             subcommand.early_reply_mode,
                             subcommand,

--- a/src/command-abstractions/text-based-command-descriptor.ts
+++ b/src/command-abstractions/text-based-command-descriptor.ts
@@ -32,7 +32,7 @@ export class BotTextBasedCommand<Args extends unknown[] = []> extends BaseBotInt
         public readonly description: string,
         public readonly slash: boolean,
         public readonly permissions: undefined | bigint,
-        public readonly category: CommandCategory,
+        public readonly category: CommandCategory | undefined,
         public readonly allow_trailing_junk: boolean,
         public readonly early_reply_mode: EarlyReplyMode,
         builder: TextBasedCommandBuilder<Args, true, true> | TextBasedCommandBuilder<Args, true, false, true>,

--- a/src/command-abstractions/text-based-command-descriptor.ts
+++ b/src/command-abstractions/text-based-command-descriptor.ts
@@ -24,6 +24,7 @@ export class BotTextBasedCommand<Args extends unknown[] = []> extends BaseBotInt
         TextBasedCommandParameterOptions & { type: TextBasedCommandOptionType }
     >();
     public readonly subcommands: Discord.Collection<string, BotTextBasedCommand<any>> | null = null;
+    public readonly all_names: string[];
 
     constructor(
         name: string,
@@ -39,6 +40,7 @@ export class BotTextBasedCommand<Args extends unknown[] = []> extends BaseBotInt
     ) {
         super(name, builder.handler ?? (async () => wheatley.critical_error("This shouldn't happen")));
         this.options = builder.options;
+        this.all_names = builder.names;
         if (builder.type === "top-level") {
             this.subcommands = new Discord.Collection();
             for (const subcommand of builder.subcommands) {
@@ -296,9 +298,10 @@ export class BotTextBasedCommand<Args extends unknown[] = []> extends BaseBotInt
         if (this.subcommands) {
             return this.subcommands.map(command => command.get_usage()).join("\n");
         } else {
+            const command_part = `!${this.all_names.join("/")}`;
             return wrap(
                 [
-                    "!" + this.display_name,
+                    command_part,
                     ...this.options.map(option => (option.required ? `<${option.title}>` : `[${option.title}]`)),
                 ].join(" "),
                 "`",

--- a/src/command-handler.ts
+++ b/src/command-handler.ts
@@ -91,6 +91,10 @@ export class CommandHandler {
         return this.text_commands[command];
     }
 
+    public get_all_commands() {
+        return this.text_commands;
+    }
+
     //
     // Command dispatch
     //

--- a/src/components/code.ts
+++ b/src/components/code.ts
@@ -18,7 +18,8 @@ export default class Code extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("code", "Misc", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("code", EarlyReplyMode.visible)
+                .set_category("Misc")
                 .set_description("code formatting help")
                 .set_allow_trailing_junk(true)
                 .set_handler(this.code.bind(this)),

--- a/src/components/code.ts
+++ b/src/components/code.ts
@@ -18,7 +18,7 @@ export default class Code extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("code", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("code", "Misc", EarlyReplyMode.visible)
                 .set_description("code formatting help")
                 .set_allow_trailing_junk(true)
                 .set_handler(this.code.bind(this)),

--- a/src/components/echo.ts
+++ b/src/components/echo.ts
@@ -21,7 +21,8 @@ export default class Echo extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("echo", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("echo", EarlyReplyMode.none)
+                .set_category("Misc")
                 .set_description("Echo")
                 .add_string_option({
                     title: "input",
@@ -31,7 +32,8 @@ export default class Echo extends BotComponent {
                 .set_handler(this.echo.bind(this)),
         );
         commands.add(
-            new TextBasedCommandBuilder("say", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("say", EarlyReplyMode.none)
+                .set_category("Misc")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Say as wheatley")
                 .set_handler(this.say.bind(this)),

--- a/src/components/echo.ts
+++ b/src/components/echo.ts
@@ -21,7 +21,7 @@ export default class Echo extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("echo", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("echo", "Misc", EarlyReplyMode.none)
                 .set_description("Echo")
                 .add_string_option({
                     title: "input",
@@ -31,7 +31,7 @@ export default class Echo extends BotComponent {
                 .set_handler(this.echo.bind(this)),
         );
         commands.add(
-            new TextBasedCommandBuilder("say", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("say", "Misc", EarlyReplyMode.none)
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Say as wheatley")
                 .set_handler(this.say.bind(this)),

--- a/src/components/google.ts
+++ b/src/components/google.ts
@@ -16,7 +16,8 @@ export default class Google extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("google", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("google", EarlyReplyMode.none)
+                .set_category("Misc")
                 .set_description("google")
                 .add_string_option({
                     title: "query",

--- a/src/components/google.ts
+++ b/src/components/google.ts
@@ -16,7 +16,7 @@ export default class Google extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("google", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("google", "Misc", EarlyReplyMode.none)
                 .set_description("google")
                 .add_string_option({
                     title: "query",

--- a/src/components/help.ts
+++ b/src/components/help.ts
@@ -191,7 +191,12 @@ export default class Help extends BotComponent {
     ): Discord.APIEmbedField[] {
         const fields: Discord.APIEmbedField[] = [];
 
-        for (const category of Help.category_order) {
+        const all_categories = [
+            ...Help.category_order,
+            ...Array.from(categories_map.keys()).filter(cat => !Help.category_order.includes(cat)),
+        ];
+
+        for (const category of all_categories) {
             if (categories_map.has(category)) {
                 const commands = unwrap(categories_map.get(category));
                 commands.sort((a, b) => a.info.localeCompare(b.info));
@@ -206,21 +211,6 @@ export default class Help extends BotComponent {
 
                 this.add_category_specific_content(category, value_parts);
 
-                fields.push(...this.split_into_fields(category, value_parts));
-            }
-        }
-
-        // TODO: Assert this doesn't happen...
-        for (const [category, commands] of categories_map.entries()) {
-            if (!Help.category_order.includes(category)) {
-                commands.sort((a, b) => a.info.localeCompare(b.info));
-                const value_parts: string[] = [];
-                for (const command of commands) {
-                    value_parts.push(command.info);
-                    if (command.aliases.length > 0) {
-                        value_parts.push(`- Shortcuts: ${command.aliases.join(", ")}`);
-                    }
-                }
                 fields.push(...this.split_into_fields(category, value_parts));
             }
         }

--- a/src/components/help.ts
+++ b/src/components/help.ts
@@ -23,13 +23,14 @@ export default class Help extends BotComponent {
     }
 
     private static readonly category_order: CommandCategory[] = [
-        "Wiki Articles",
         "References",
+        "Wiki Articles",
         "Thread Control",
         "Utility",
         "Misc",
         "Moderation",
         "Moderation Utilities",
+        "Admin utilities",
     ];
 
     override async setup(commands: CommandSetBuilder) {

--- a/src/components/help.ts
+++ b/src/components/help.ts
@@ -108,6 +108,11 @@ export default class Help extends BotComponent {
             }
         }
 
+        // Sort aliases alphabetically
+        for (const aliases of command_name_to_aliases.values()) {
+            aliases.sort((a, b) => a.localeCompare(b));
+        }
+
         // Second pass: build command map with aliases
         for (const command_descriptor of Object.values(all_commands)) {
             // If this command has subcommands, process them instead of the parent
@@ -189,6 +194,7 @@ export default class Help extends BotComponent {
         for (const category of Help.category_order) {
             if (categories_map.has(category)) {
                 const commands = unwrap(categories_map.get(category));
+                commands.sort((a, b) => a.info.localeCompare(b.info));
                 const value_parts: string[] = [];
 
                 for (const command of commands) {
@@ -207,6 +213,7 @@ export default class Help extends BotComponent {
         // TODO: Assert this doesn't happen...
         for (const [category, commands] of categories_map.entries()) {
             if (!Help.category_order.includes(category)) {
+                commands.sort((a, b) => a.info.localeCompare(b.info));
                 const value_parts: string[] = [];
                 for (const command of commands) {
                     value_parts.push(command.info);

--- a/src/components/help.ts
+++ b/src/components/help.ts
@@ -36,7 +36,8 @@ export default class Help extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("help", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("help", EarlyReplyMode.none)
+                .set_category("Misc")
                 .set_description("Bot help and info")
                 .set_handler(this.help.bind(this)),
         );
@@ -60,7 +61,7 @@ export default class Help extends BotComponent {
                 continue;
             }
 
-            const category = command_descriptor.category;
+            const category = command_descriptor.category ?? "Misc";
             if (category === "Hidden") {
                 continue;
             }

--- a/src/components/help.ts
+++ b/src/components/help.ts
@@ -9,7 +9,11 @@ import { colors } from "../common.js";
 import { BotComponent } from "../bot-component.js";
 import { CommandSetBuilder } from "../command-abstractions/command-set-builder.js";
 import { Wheatley } from "../wheatley.js";
-import { EarlyReplyMode, TextBasedCommandBuilder } from "../command-abstractions/text-based-command-builder.js";
+import {
+    EarlyReplyMode,
+    TextBasedCommandBuilder,
+    CommandCategory,
+} from "../command-abstractions/text-based-command-builder.js";
 import { TextBasedCommand } from "../command-abstractions/text-based-command.js";
 import Wiki from "./wiki.js";
 
@@ -18,108 +22,169 @@ export default class Help extends BotComponent {
         return true;
     }
 
+    private static readonly category_order: CommandCategory[] = [
+        "Wiki Articles",
+        "References",
+        "Thread Control",
+        "Utility",
+        "Misc",
+        "Moderation",
+        "Moderation Utilities",
+    ];
+
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("help", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("help", "Misc", EarlyReplyMode.none)
                 .set_description("Bot help and info")
                 .set_handler(this.help.bind(this)),
         );
     }
 
-    command_info(...commands: string[]) {
-        return commands.map(command => this.wheatley.get_command(command).get_command_info());
+    private build_commands_map(user_permissions: Discord.PermissionsBitField): Map<CommandCategory, string[]> {
+        const all_commands = this.wheatley.get_all_commands();
+        const categories_map = new Map<CommandCategory, string[]>();
+
+        for (const command_descriptor of Object.values(all_commands)) {
+            if (command_descriptor.subcommands) {
+                continue;
+            }
+
+            if (
+                command_descriptor.permissions !== undefined &&
+                command_descriptor.permissions !== 0n &&
+                !user_permissions.has(command_descriptor.permissions)
+            ) {
+                continue;
+            }
+
+            const category = command_descriptor.category;
+            if (!categories_map.has(category)) {
+                categories_map.set(category, []);
+            }
+            unwrap(categories_map.get(category)).push(command_descriptor.get_command_info());
+        }
+
+        return categories_map;
+    }
+
+    private add_category_specific_content(category: CommandCategory, value_parts: string[]): void {
+        if (category === "Wiki Articles") {
+            const wiki_component = this.wheatley.components.get("Wiki");
+            if (wiki_component) {
+                value_parts.push(
+                    "Article shortcuts: " +
+                        (wiki_component as Wiki).article_aliases.map((_, alias) => `\`${alias}\``).join(", "),
+                    "Article contributions are welcome [here](https://github.com/TCCPP/wiki)!",
+                );
+            }
+        } else if (category === "Utility") {
+            value_parts.unshift("`!f <reply>` Format the message being replied to");
+        } else if (category === "Moderation") {
+            const noofftopic_command = this.wheatley.get_command("noofftopic");
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+            if (noofftopic_command) {
+                value_parts.push(
+                    "Rolepersist aliases: `noofftopic`, `nosuggestions`, `nosuggestionsatall`, " +
+                        "`noreactions`, `nothreads`, `noseriousofftopic`, `notil`, `nomemes`. " +
+                        `Syntax: \`${noofftopic_command.get_usage().replace("noofftopic", "(alias)")}\``,
+                    "Durations: `perm` for permanent or `number unit` (whitespace ignored)." +
+                        " Units are y, M, w, d, h, m, s.",
+                );
+            }
+        }
+    }
+
+    private split_into_fields(
+        category: CommandCategory,
+        value_parts: string[],
+        max_length: number = 1024,
+    ): Discord.APIEmbedField[] {
+        const fields: Discord.APIEmbedField[] = [];
+        let current_parts: string[] = [];
+        let current_length = 0;
+
+        for (const part of value_parts) {
+            const part_length = part.length + 1;
+            if (current_length + part_length > max_length && current_parts.length > 0) {
+                fields.push({
+                    name: fields.length === 0 ? category : `${category} (cont.)`,
+                    value: build_description(...current_parts),
+                });
+                current_parts = [];
+                current_length = 0;
+            }
+            current_parts.push(part);
+            current_length += part_length;
+        }
+
+        if (current_parts.length > 0) {
+            fields.push({
+                name: fields.length === 0 ? category : `${category} (cont.)`,
+                value: build_description(...current_parts),
+            });
+        }
+
+        return fields;
+    }
+
+    private build_category_fields(categories_map: Map<CommandCategory, string[]>): Discord.APIEmbedField[] {
+        const fields: Discord.APIEmbedField[] = [];
+
+        for (const category of Help.category_order) {
+            if (categories_map.has(category)) {
+                const commands = unwrap(categories_map.get(category));
+                const value_parts = [...commands];
+
+                this.add_category_specific_content(category, value_parts);
+
+                fields.push(...this.split_into_fields(category, value_parts));
+            }
+        }
+
+        // TODO: Assert this doesn't happen...
+        for (const [category, commands] of categories_map.entries()) {
+            if (!Help.category_order.includes(category)) {
+                fields.push(...this.split_into_fields(category, commands));
+            }
+        }
+
+        return fields;
+    }
+
+    private build_help_embeds(fields: Discord.APIEmbedField[]): Discord.EmbedBuilder[] {
+        const embeds: Discord.EmbedBuilder[] = [];
+        const main_embed = new Discord.EmbedBuilder()
+            .setColor(colors.wheatley)
+            .setTitle("Wheatley")
+            .setDescription(
+                build_description(
+                    "Wheatley discord bot for the Together C & C++ server. The bot is open source, contributions " +
+                        "are welcome at https://github.com/TCCPP/wheatley.",
+                ),
+            )
+            .setThumbnail("https://avatars.githubusercontent.com/u/142943210");
+
+        const non_mod_fields = fields.filter(field => !field.name.toLowerCase().includes("moderation"));
+        const mod_fields = fields.filter(field => field.name.toLowerCase().includes("moderation"));
+
+        main_embed.addFields(...non_mod_fields);
+        embeds.push(main_embed);
+
+        if (mod_fields.length > 0) {
+            embeds.push(new Discord.EmbedBuilder().setColor(colors.wheatley).addFields(...mod_fields));
+        }
+
+        return embeds;
     }
 
     async help(command: TextBasedCommand) {
-        const embeds = [
-            new Discord.EmbedBuilder()
-                .setColor(colors.wheatley)
-                .setTitle("Wheatley")
-                .setDescription(
-                    build_description(
-                        "Wheatley discord bot for the Together C & C++ server. The bot is open source, contributions " +
-                            "are welcome at https://github.com/TCCPP/wheatley.",
-                    ),
-                )
-                .setThumbnail("https://avatars.githubusercontent.com/u/142943210")
-                .addFields(
-                    {
-                        name: "Wiki Articles",
-                        value: build_description(
-                            ...this.command_info("wiki", "wiki-preview"),
-                            "Article shortcuts: " +
-                                (unwrap(this.wheatley.components.get("Wiki")) as Wiki).article_aliases
-                                    .map((_, alias) => `\`${alias}\``)
-                                    .join(", "),
-                            "Article contributions are welcome [here](https://github.com/TCCPP/wiki)!",
-                        ),
-                    },
-                    {
-                        name: "References",
-                        value: build_description(...this.command_info("cppref", "cref", "man")),
-                    },
-                    {
-                        name: "Thread Control",
-                        value: build_description(...this.command_info("solved", "unsolved", "archive", "rename")),
-                    },
-                    {
-                        name: "Utility",
-                        value: build_description(
-                            "`!f <reply>` Format the message being replied to",
-                            ...this.command_info(
-                                "quote",
-                                "quoteb",
-                                "snowflake",
-                                "inspect",
-                                "nodistractions",
-                                "removenodistractions",
-                            ),
-                        ),
-                    },
-                    {
-                        name: "Misc",
-                        value: build_description(...this.command_info("ping", "echo", "r")),
-                    },
-                ),
-        ];
-        if (await this.wheatley.check_permissions(command.user, Discord.PermissionFlagsBits.ModerateMembers)) {
-            embeds.push(
-                new Discord.EmbedBuilder().setColor(colors.wheatley).addFields(
-                    {
-                        name: "Moderation",
-                        value: build_description(
-                            ...this.command_info(
-                                "ban",
-                                "unban",
-                                "kick",
-                                "mute",
-                                "unmute",
-                                "rolepersist",
-                                "timeout",
-                                "warn",
-                                "reason",
-                                "duration",
-                                "expunge",
-                                "modlogs",
-                                "case",
-                            ),
-                            "Rolepersist aliases: `noofftopic`, `nosuggestions`, `nosuggestionsatall`, " +
-                                "`noreactions`, `nothreads`, `noseriousofftopic`, `notil`, `nomemes`. " +
-                                `Syntax: \`${this.wheatley
-                                    .get_command("noofftopic")
-                                    .get_usage()
-                                    .replace("noofftopic", "(alias)")}\``,
-                            "Durations: `perm` for permanent or `number unit` (whitespace ignored)." +
-                                " Units are y, M, w, d, h, m, s.",
-                        ),
-                    },
-                    {
-                        name: "Moderation utilities",
-                        value: build_description(...this.command_info("redirect", "purge")),
-                    },
-                ),
-            );
-        }
+        const member = await this.wheatley.guild.members.fetch(command.user.id);
+        const user_permissions = member.permissions;
+
+        const categories_map = this.build_commands_map(user_permissions);
+        const fields = this.build_category_fields(categories_map);
+        const embeds = this.build_help_embeds(fields);
+
         await command.reply({
             embeds,
             ephemeral_if_possible: true,

--- a/src/components/inspect.ts
+++ b/src/components/inspect.ts
@@ -87,7 +87,7 @@ export default class Inspect extends BotComponent {
 
         // Permissions on this command in the interest of preventing spam (intentional or otherwise)
         commands.add(
-            new TextBasedCommandBuilder("inspect", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("inspect", "Utility", EarlyReplyMode.ephemeral)
                 .set_description("Inspect a message")
                 .add_string_option({
                     title: "url",

--- a/src/components/inspect.ts
+++ b/src/components/inspect.ts
@@ -87,7 +87,8 @@ export default class Inspect extends BotComponent {
 
         // Permissions on this command in the interest of preventing spam (intentional or otherwise)
         commands.add(
-            new TextBasedCommandBuilder("inspect", "Utility", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("inspect", EarlyReplyMode.ephemeral)
+                .set_category("Utility")
                 .set_description("Inspect a message")
                 .add_string_option({
                     title: "url",

--- a/src/components/members.ts
+++ b/src/components/members.ts
@@ -17,7 +17,8 @@ export default class Members extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("members", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("members", EarlyReplyMode.none)
+                .set_category("Misc")
                 .set_description("Members")
                 .set_handler(this.members.bind(this)),
         );

--- a/src/components/members.ts
+++ b/src/components/members.ts
@@ -17,7 +17,7 @@ export default class Members extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("members", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("members", "Misc", EarlyReplyMode.none)
                 .set_description("Members")
                 .set_handler(this.members.bind(this)),
         );

--- a/src/components/moderation/ban.ts
+++ b/src/components/moderation/ban.ts
@@ -25,7 +25,7 @@ export default class Ban extends ModerationComponent {
     override async setup(commands: CommandSetBuilder) {
         await super.setup(commands);
         commands.add(
-            new TextBasedCommandBuilder("ban", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("ban", "Moderation", EarlyReplyMode.visible)
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Ban user")
                 .add_user_option({
@@ -51,7 +51,7 @@ export default class Ban extends ModerationComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("massban", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("massban", "Moderation", EarlyReplyMode.visible)
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Ban users")
                 .set_slash(false)
@@ -82,7 +82,7 @@ export default class Ban extends ModerationComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("unban", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("unban", "Moderation", EarlyReplyMode.visible)
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Unban user")
                 .add_user_option({

--- a/src/components/moderation/ban.ts
+++ b/src/components/moderation/ban.ts
@@ -25,7 +25,8 @@ export default class Ban extends ModerationComponent {
     override async setup(commands: CommandSetBuilder) {
         await super.setup(commands);
         commands.add(
-            new TextBasedCommandBuilder("ban", "Moderation", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("ban", EarlyReplyMode.visible)
+                .set_category("Moderation")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Ban user")
                 .add_user_option({
@@ -51,7 +52,8 @@ export default class Ban extends ModerationComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("massban", "Moderation", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("massban", EarlyReplyMode.visible)
+                .set_category("Moderation")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Ban users")
                 .set_slash(false)
@@ -82,7 +84,8 @@ export default class Ban extends ModerationComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("unban", "Moderation", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("unban", EarlyReplyMode.visible)
+                .set_category("Moderation")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Unban user")
                 .add_user_option({

--- a/src/components/moderation/kick.ts
+++ b/src/components/moderation/kick.ts
@@ -29,7 +29,8 @@ export default class Kick extends ModerationComponent {
     override async setup(commands: CommandSetBuilder) {
         await super.setup(commands);
         commands.add(
-            new TextBasedCommandBuilder("kick", "Moderation", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("kick", EarlyReplyMode.visible)
+                .set_category("Moderation")
                 .set_permissions(Discord.PermissionFlagsBits.KickMembers)
                 .set_description("Kick user")
                 .add_user_option({

--- a/src/components/moderation/kick.ts
+++ b/src/components/moderation/kick.ts
@@ -29,7 +29,7 @@ export default class Kick extends ModerationComponent {
     override async setup(commands: CommandSetBuilder) {
         await super.setup(commands);
         commands.add(
-            new TextBasedCommandBuilder("kick", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("kick", "Moderation", EarlyReplyMode.visible)
                 .set_permissions(Discord.PermissionFlagsBits.KickMembers)
                 .set_description("Kick user")
                 .add_user_option({

--- a/src/components/moderation/moderation-control.ts
+++ b/src/components/moderation/moderation-control.ts
@@ -26,7 +26,8 @@ export default class ModerationControl extends BotComponent {
         this.staff_action_log = await this.utilities.get_channel(this.wheatley.channels.staff_action_log);
         this.public_action_log = await this.utilities.get_channel(this.wheatley.channels.public_action_log);
         commands.add(
-            new TextBasedCommandBuilder("reason", "Moderation", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("reason", EarlyReplyMode.visible)
+                .set_category("Moderation")
                 .set_description("Update the reason for a case")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .add_number_option({
@@ -43,11 +44,12 @@ export default class ModerationControl extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("context", "Moderation", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("context", EarlyReplyMode.visible)
+                .set_category("Moderation")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Update case context")
                 .add_subcommand(
-                    new TextBasedCommandBuilder("add", "Misc", EarlyReplyMode.visible)
+                    new TextBasedCommandBuilder("add", EarlyReplyMode.visible)
                         .set_description("Add context")
                         .add_number_option({
                             title: "case",
@@ -64,7 +66,8 @@ export default class ModerationControl extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("duration", "Moderation", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("duration", EarlyReplyMode.visible)
+                .set_category("Moderation")
                 .set_description("Update the duration for a case")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .add_number_option({
@@ -81,7 +84,8 @@ export default class ModerationControl extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("expunge", "Moderation", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("expunge", EarlyReplyMode.visible)
+                .set_category("Moderation")
                 .set_description("Expunge a case")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .add_number_option({

--- a/src/components/moderation/moderation-control.ts
+++ b/src/components/moderation/moderation-control.ts
@@ -26,7 +26,7 @@ export default class ModerationControl extends BotComponent {
         this.staff_action_log = await this.utilities.get_channel(this.wheatley.channels.staff_action_log);
         this.public_action_log = await this.utilities.get_channel(this.wheatley.channels.public_action_log);
         commands.add(
-            new TextBasedCommandBuilder("reason", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("reason", "Moderation", EarlyReplyMode.visible)
                 .set_description("Update the reason for a case")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .add_number_option({
@@ -43,11 +43,11 @@ export default class ModerationControl extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("context", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("context", "Moderation", EarlyReplyMode.visible)
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Update case context")
                 .add_subcommand(
-                    new TextBasedCommandBuilder("add", EarlyReplyMode.visible)
+                    new TextBasedCommandBuilder("add", "Misc", EarlyReplyMode.visible)
                         .set_description("Add context")
                         .add_number_option({
                             title: "case",
@@ -64,7 +64,7 @@ export default class ModerationControl extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("duration", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("duration", "Moderation", EarlyReplyMode.visible)
                 .set_description("Update the duration for a case")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .add_number_option({
@@ -81,7 +81,7 @@ export default class ModerationControl extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("expunge", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("expunge", "Moderation", EarlyReplyMode.visible)
                 .set_description("Expunge a case")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .add_number_option({

--- a/src/components/moderation/modlogs.ts
+++ b/src/components/moderation/modlogs.ts
@@ -29,7 +29,7 @@ export default class Modlogs extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("modlogs", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("modlogs", "Moderation", EarlyReplyMode.visible)
                 .set_description("Get user moderation logs")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .add_user_option({
@@ -41,7 +41,7 @@ export default class Modlogs extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("case", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("case", "Moderation", EarlyReplyMode.visible)
                 .set_description("Get case info")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .add_number_option({

--- a/src/components/moderation/modlogs.ts
+++ b/src/components/moderation/modlogs.ts
@@ -29,7 +29,8 @@ export default class Modlogs extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("modlogs", "Moderation", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("modlogs", EarlyReplyMode.visible)
+                .set_category("Moderation")
                 .set_description("Get user moderation logs")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .add_user_option({
@@ -41,7 +42,8 @@ export default class Modlogs extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("case", "Moderation", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("case", EarlyReplyMode.visible)
+                .set_category("Moderation")
                 .set_description("Get case info")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .add_number_option({

--- a/src/components/moderation/modmail.ts
+++ b/src/components/moderation/modmail.ts
@@ -62,14 +62,16 @@ export default class Modmail extends BotComponent {
         this.mods = await this.utilities.get_channel(this.wheatley.channels.mods);
         this.staff_member_log = await this.utilities.get_channel(this.wheatley.channels.staff_member_log);
         commands.add(
-            new TextBasedCommandBuilder("wsetupmodmailsystem", "Admin utilities", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("wsetupmodmailsystem", EarlyReplyMode.none)
+                .set_category("Admin utilities")
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_description("Create modmail message here")
                 .set_slash(false)
                 .set_handler(this.modmail_setup.bind(this)),
         );
         commands.add(
-            new TextBasedCommandBuilder("wupdatemodmailsystem", "Admin utilities", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("wupdatemodmailsystem", EarlyReplyMode.none)
+                .set_category("Admin utilities")
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_description("Update modmail message")
                 .set_slash(false)

--- a/src/components/moderation/modmail.ts
+++ b/src/components/moderation/modmail.ts
@@ -62,14 +62,14 @@ export default class Modmail extends BotComponent {
         this.mods = await this.utilities.get_channel(this.wheatley.channels.mods);
         this.staff_member_log = await this.utilities.get_channel(this.wheatley.channels.staff_member_log);
         commands.add(
-            new TextBasedCommandBuilder("wsetupmodmailsystem", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("wsetupmodmailsystem", "Misc", EarlyReplyMode.none)
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_description("Create modmail message here")
                 .set_slash(false)
                 .set_handler(this.modmail_setup.bind(this)),
         );
         commands.add(
-            new TextBasedCommandBuilder("wupdatemodmailsystem", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("wupdatemodmailsystem", "Misc", EarlyReplyMode.none)
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_description("Update modmail message")
                 .set_slash(false)

--- a/src/components/moderation/modmail.ts
+++ b/src/components/moderation/modmail.ts
@@ -62,14 +62,14 @@ export default class Modmail extends BotComponent {
         this.mods = await this.utilities.get_channel(this.wheatley.channels.mods);
         this.staff_member_log = await this.utilities.get_channel(this.wheatley.channels.staff_member_log);
         commands.add(
-            new TextBasedCommandBuilder("wsetupmodmailsystem", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("wsetupmodmailsystem", "Admin utilities", EarlyReplyMode.none)
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_description("Create modmail message here")
                 .set_slash(false)
                 .set_handler(this.modmail_setup.bind(this)),
         );
         commands.add(
-            new TextBasedCommandBuilder("wupdatemodmailsystem", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("wupdatemodmailsystem", "Admin utilities", EarlyReplyMode.none)
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_description("Update modmail message")
                 .set_slash(false)

--- a/src/components/moderation/modstats.ts
+++ b/src/components/moderation/modstats.ts
@@ -21,7 +21,8 @@ export default class ModStats extends BotComponent {
     override async setup(commands: CommandSetBuilder) {
         this.bot_spam = await this.utilities.get_channel(this.wheatley.channels.bot_spam);
         commands.add(
-            new TextBasedCommandBuilder("modstats", "Moderation", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("modstats", EarlyReplyMode.none)
+                .set_category("Moderation")
                 .set_description("Moderator stats")
                 .set_permissions(Discord.PermissionFlagsBits.ModerateMembers)
                 .add_user_option({

--- a/src/components/moderation/modstats.ts
+++ b/src/components/moderation/modstats.ts
@@ -21,7 +21,7 @@ export default class ModStats extends BotComponent {
     override async setup(commands: CommandSetBuilder) {
         this.bot_spam = await this.utilities.get_channel(this.wheatley.channels.bot_spam);
         commands.add(
-            new TextBasedCommandBuilder("modstats", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("modstats", "Moderation", EarlyReplyMode.none)
                 .set_description("Moderator stats")
                 .set_permissions(Discord.PermissionFlagsBits.ModerateMembers)
                 .add_user_option({

--- a/src/components/moderation/modstats.ts
+++ b/src/components/moderation/modstats.ts
@@ -21,7 +21,7 @@ export default class ModStats extends BotComponent {
     override async setup(commands: CommandSetBuilder) {
         this.bot_spam = await this.utilities.get_channel(this.wheatley.channels.bot_spam);
         commands.add(
-            new TextBasedCommandBuilder("modstats", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("modstats", "Misc", EarlyReplyMode.none)
                 .set_description("Moderator stats")
                 .set_permissions(Discord.PermissionFlagsBits.ModerateMembers)
                 .add_user_option({

--- a/src/components/moderation/mute.ts
+++ b/src/components/moderation/mute.ts
@@ -27,7 +27,8 @@ export default class Mute extends ModerationComponent {
     override async setup(commands: CommandSetBuilder) {
         await super.setup(commands);
         commands.add(
-            new TextBasedCommandBuilder("mute", "Moderation", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("mute", EarlyReplyMode.visible)
+                .set_category("Moderation")
                 .set_permissions(Discord.PermissionFlagsBits.ModerateMembers)
                 .set_description("Mute user")
                 .add_user_option({
@@ -53,7 +54,8 @@ export default class Mute extends ModerationComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("unmute", "Moderation", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("unmute", EarlyReplyMode.visible)
+                .set_category("Moderation")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Unmute user")
                 .add_user_option({

--- a/src/components/moderation/mute.ts
+++ b/src/components/moderation/mute.ts
@@ -27,7 +27,7 @@ export default class Mute extends ModerationComponent {
     override async setup(commands: CommandSetBuilder) {
         await super.setup(commands);
         commands.add(
-            new TextBasedCommandBuilder("mute", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("mute", "Moderation", EarlyReplyMode.visible)
                 .set_permissions(Discord.PermissionFlagsBits.ModerateMembers)
                 .set_description("Mute user")
                 .add_user_option({
@@ -53,7 +53,7 @@ export default class Mute extends ModerationComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("unmute", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("unmute", "Moderation", EarlyReplyMode.visible)
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Unmute user")
                 .add_user_option({

--- a/src/components/moderation/note.ts
+++ b/src/components/moderation/note.ts
@@ -28,7 +28,7 @@ export default class Note extends ModerationComponent {
     override async setup(commands: CommandSetBuilder) {
         await super.setup(commands);
         commands.add(
-            new TextBasedCommandBuilder("note", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("note", "Misc", EarlyReplyMode.ephemeral)
                 .set_permissions(Discord.PermissionFlagsBits.ModerateMembers)
                 .set_description("Enter note in modlogs")
                 .add_user_option({

--- a/src/components/moderation/note.ts
+++ b/src/components/moderation/note.ts
@@ -28,7 +28,8 @@ export default class Note extends ModerationComponent {
     override async setup(commands: CommandSetBuilder) {
         await super.setup(commands);
         commands.add(
-            new TextBasedCommandBuilder("note", "Moderation", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("note", EarlyReplyMode.ephemeral)
+                .set_category("Moderation")
                 .set_permissions(Discord.PermissionFlagsBits.ModerateMembers)
                 .set_description("Enter note in modlogs")
                 .add_user_option({

--- a/src/components/moderation/note.ts
+++ b/src/components/moderation/note.ts
@@ -28,7 +28,7 @@ export default class Note extends ModerationComponent {
     override async setup(commands: CommandSetBuilder) {
         await super.setup(commands);
         commands.add(
-            new TextBasedCommandBuilder("note", "Misc", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("note", "Moderation", EarlyReplyMode.ephemeral)
                 .set_permissions(Discord.PermissionFlagsBits.ModerateMembers)
                 .set_description("Enter note in modlogs")
                 .add_user_option({

--- a/src/components/moderation/purge.ts
+++ b/src/components/moderation/purge.ts
@@ -58,11 +58,11 @@ export default class Purge extends BotComponent {
         // purge user
 
         commands.add(
-            new TextBasedCommandBuilder("purge", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("purge", "Moderation Utilities", EarlyReplyMode.visible)
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Purge messages")
                 .add_subcommand(
-                    new TextBasedCommandBuilder("count", EarlyReplyMode.visible)
+                    new TextBasedCommandBuilder("count", "Misc", EarlyReplyMode.visible)
                         .set_description("Purge the most recent N messages")
                         .add_number_option({
                             title: "count",
@@ -72,7 +72,7 @@ export default class Purge extends BotComponent {
                         .set_handler(this.purge_count.bind(this)),
                 )
                 .add_subcommand(
-                    new TextBasedCommandBuilder("after", EarlyReplyMode.visible)
+                    new TextBasedCommandBuilder("after", "Misc", EarlyReplyMode.visible)
                         .set_description("Purge all messages after snowflake")
                         .add_string_option({
                             title: "url",
@@ -82,7 +82,7 @@ export default class Purge extends BotComponent {
                         .set_handler(this.purge_after.bind(this)),
                 )
                 .add_subcommand(
-                    new TextBasedCommandBuilder("range", EarlyReplyMode.visible)
+                    new TextBasedCommandBuilder("range", "Misc", EarlyReplyMode.visible)
                         .set_description("Purge all messages between start and end")
                         .add_string_option({
                             title: "start",
@@ -97,7 +97,7 @@ export default class Purge extends BotComponent {
                         .set_handler(this.purge_range.bind(this)),
                 )
                 .add_subcommand(
-                    new TextBasedCommandBuilder("user", EarlyReplyMode.visible)
+                    new TextBasedCommandBuilder("user", "Misc", EarlyReplyMode.visible)
                         .set_description("Purge the all messages from a user over a specific timeframe")
                         .add_user_option({
                             title: "user",
@@ -119,7 +119,7 @@ export default class Purge extends BotComponent {
                         .set_handler(this.purge_user.bind(this)),
                 )
                 .add_subcommand(
-                    new TextBasedCommandBuilder("user-in-channel", EarlyReplyMode.visible)
+                    new TextBasedCommandBuilder("user-in-channel", "Misc", EarlyReplyMode.visible)
                         .set_description("Purge the all messages from a user over a specific timeframe in one channel")
                         .add_user_option({
                             title: "user",
@@ -150,7 +150,7 @@ export default class Purge extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("dummymessages", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("dummymessages", "Misc", EarlyReplyMode.visible)
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("dummymessages")
                 .add_number_option({

--- a/src/components/moderation/purge.ts
+++ b/src/components/moderation/purge.ts
@@ -58,11 +58,12 @@ export default class Purge extends BotComponent {
         // purge user
 
         commands.add(
-            new TextBasedCommandBuilder("purge", "Moderation Utilities", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("purge", EarlyReplyMode.visible)
+                .set_category("Moderation Utilities")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Purge messages")
                 .add_subcommand(
-                    new TextBasedCommandBuilder("count", "Misc", EarlyReplyMode.visible)
+                    new TextBasedCommandBuilder("count", EarlyReplyMode.visible)
                         .set_description("Purge the most recent N messages")
                         .add_number_option({
                             title: "count",
@@ -72,7 +73,7 @@ export default class Purge extends BotComponent {
                         .set_handler(this.purge_count.bind(this)),
                 )
                 .add_subcommand(
-                    new TextBasedCommandBuilder("after", "Misc", EarlyReplyMode.visible)
+                    new TextBasedCommandBuilder("after", EarlyReplyMode.visible)
                         .set_description("Purge all messages after snowflake")
                         .add_string_option({
                             title: "url",
@@ -82,7 +83,7 @@ export default class Purge extends BotComponent {
                         .set_handler(this.purge_after.bind(this)),
                 )
                 .add_subcommand(
-                    new TextBasedCommandBuilder("range", "Misc", EarlyReplyMode.visible)
+                    new TextBasedCommandBuilder("range", EarlyReplyMode.visible)
                         .set_description("Purge all messages between start and end")
                         .add_string_option({
                             title: "start",
@@ -97,7 +98,7 @@ export default class Purge extends BotComponent {
                         .set_handler(this.purge_range.bind(this)),
                 )
                 .add_subcommand(
-                    new TextBasedCommandBuilder("user", "Misc", EarlyReplyMode.visible)
+                    new TextBasedCommandBuilder("user", EarlyReplyMode.visible)
                         .set_description("Purge the all messages from a user over a specific timeframe")
                         .add_user_option({
                             title: "user",
@@ -119,7 +120,7 @@ export default class Purge extends BotComponent {
                         .set_handler(this.purge_user.bind(this)),
                 )
                 .add_subcommand(
-                    new TextBasedCommandBuilder("user-in-channel", "Misc", EarlyReplyMode.visible)
+                    new TextBasedCommandBuilder("user-in-channel", EarlyReplyMode.visible)
                         .set_description("Purge the all messages from a user over a specific timeframe in one channel")
                         .add_user_option({
                             title: "user",
@@ -150,7 +151,8 @@ export default class Purge extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("dummymessages", "Misc", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("dummymessages", EarlyReplyMode.visible)
+                .set_category("Misc")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("dummymessages")
                 .add_number_option({

--- a/src/components/moderation/rolepersist.ts
+++ b/src/components/moderation/rolepersist.ts
@@ -112,7 +112,7 @@ export default class Rolepersist extends ModerationComponent {
 
         for (const [command, role] of Object.entries(aliases)) {
             commands.add(
-                new TextBasedCommandBuilder(command, "Moderation", EarlyReplyMode.visible)
+                new TextBasedCommandBuilder(command, "Rolepersist Shortcuts", EarlyReplyMode.visible)
                     .set_permissions(Discord.PermissionFlagsBits.ModerateMembers)
                     .set_description(`${capitalize(role).replace("_", " ")}`)
                     .add_user_option({

--- a/src/components/moderation/rolepersist.ts
+++ b/src/components/moderation/rolepersist.ts
@@ -114,7 +114,8 @@ export default class Rolepersist extends ModerationComponent {
         for (const [command, role] of Object.entries(aliases)) {
             commands.add(
                 new TextBasedCommandBuilder(command, EarlyReplyMode.visible)
-                    .set_category("Rolepersist Shortcuts")
+                    .set_category("Moderation")
+                    .set_alias_of("rolepersist add")
                     .set_permissions(Discord.PermissionFlagsBits.ModerateMembers)
                     .set_description(`${capitalize(role).replace("_", " ")}`)
                     .add_user_option({

--- a/src/components/moderation/rolepersist.ts
+++ b/src/components/moderation/rolepersist.ts
@@ -27,11 +27,12 @@ export default class Rolepersist extends ModerationComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("rolepersist", "Moderation", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("rolepersist", EarlyReplyMode.visible)
+                .set_category("Moderation")
                 .set_permissions(Discord.PermissionFlagsBits.ModerateMembers)
                 .set_description("Rolepersist add/remove")
                 .add_subcommand(
-                    new TextBasedCommandBuilder("add", "Misc", EarlyReplyMode.visible)
+                    new TextBasedCommandBuilder("add", EarlyReplyMode.visible)
                         .set_description("Rolepersist user")
                         .add_user_option({
                             title: "user",
@@ -70,7 +71,7 @@ export default class Rolepersist extends ModerationComponent {
                         ),
                 )
                 .add_subcommand(
-                    new TextBasedCommandBuilder("remove", "Misc", EarlyReplyMode.visible)
+                    new TextBasedCommandBuilder("remove", EarlyReplyMode.visible)
                         .set_description("Rolepersist remove user")
                         .add_user_option({
                             title: "user",
@@ -112,7 +113,8 @@ export default class Rolepersist extends ModerationComponent {
 
         for (const [command, role] of Object.entries(aliases)) {
             commands.add(
-                new TextBasedCommandBuilder(command, "Rolepersist Shortcuts", EarlyReplyMode.visible)
+                new TextBasedCommandBuilder(command, EarlyReplyMode.visible)
+                    .set_category("Rolepersist Shortcuts")
                     .set_permissions(Discord.PermissionFlagsBits.ModerateMembers)
                     .set_description(`${capitalize(role).replace("_", " ")}`)
                     .add_user_option({

--- a/src/components/moderation/rolepersist.ts
+++ b/src/components/moderation/rolepersist.ts
@@ -27,11 +27,11 @@ export default class Rolepersist extends ModerationComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("rolepersist", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("rolepersist", "Moderation", EarlyReplyMode.visible)
                 .set_permissions(Discord.PermissionFlagsBits.ModerateMembers)
                 .set_description("Rolepersist add/remove")
                 .add_subcommand(
-                    new TextBasedCommandBuilder("add", EarlyReplyMode.visible)
+                    new TextBasedCommandBuilder("add", "Misc", EarlyReplyMode.visible)
                         .set_description("Rolepersist user")
                         .add_user_option({
                             title: "user",
@@ -70,7 +70,7 @@ export default class Rolepersist extends ModerationComponent {
                         ),
                 )
                 .add_subcommand(
-                    new TextBasedCommandBuilder("remove", EarlyReplyMode.visible)
+                    new TextBasedCommandBuilder("remove", "Misc", EarlyReplyMode.visible)
                         .set_description("Rolepersist remove user")
                         .add_user_option({
                             title: "user",
@@ -112,7 +112,7 @@ export default class Rolepersist extends ModerationComponent {
 
         for (const [command, role] of Object.entries(aliases)) {
             commands.add(
-                new TextBasedCommandBuilder(command, EarlyReplyMode.visible)
+                new TextBasedCommandBuilder(command, "Moderation", EarlyReplyMode.visible)
                     .set_permissions(Discord.PermissionFlagsBits.ModerateMembers)
                     .set_description(`${capitalize(role).replace("_", " ")}`)
                     .add_user_option({

--- a/src/components/moderation/timeout.ts
+++ b/src/components/moderation/timeout.ts
@@ -25,11 +25,12 @@ export default class Timeout extends ModerationComponent {
     override async setup(commands: CommandSetBuilder) {
         await super.setup(commands);
         commands.add(
-            new TextBasedCommandBuilder("timeout", "Moderation", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("timeout", EarlyReplyMode.visible)
+                .set_category("Moderation")
                 .set_permissions(Discord.PermissionFlagsBits.ModerateMembers)
                 .set_description("Timeout add / remove")
                 .add_subcommand(
-                    new TextBasedCommandBuilder("add", "Misc", EarlyReplyMode.visible)
+                    new TextBasedCommandBuilder("add", EarlyReplyMode.visible)
                         .set_description("Timeout user")
                         .add_user_option({
                             title: "user",
@@ -75,7 +76,7 @@ export default class Timeout extends ModerationComponent {
                         ),
                 )
                 .add_subcommand(
-                    new TextBasedCommandBuilder("remove", "Misc", EarlyReplyMode.visible)
+                    new TextBasedCommandBuilder("remove", EarlyReplyMode.visible)
                         .set_description("Timeout remove user")
                         .add_user_option({
                             title: "user",

--- a/src/components/moderation/timeout.ts
+++ b/src/components/moderation/timeout.ts
@@ -25,11 +25,11 @@ export default class Timeout extends ModerationComponent {
     override async setup(commands: CommandSetBuilder) {
         await super.setup(commands);
         commands.add(
-            new TextBasedCommandBuilder("timeout", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("timeout", "Moderation", EarlyReplyMode.visible)
                 .set_permissions(Discord.PermissionFlagsBits.ModerateMembers)
                 .set_description("Timeout add / remove")
                 .add_subcommand(
-                    new TextBasedCommandBuilder("add", EarlyReplyMode.visible)
+                    new TextBasedCommandBuilder("add", "Misc", EarlyReplyMode.visible)
                         .set_description("Timeout user")
                         .add_user_option({
                             title: "user",
@@ -75,7 +75,7 @@ export default class Timeout extends ModerationComponent {
                         ),
                 )
                 .add_subcommand(
-                    new TextBasedCommandBuilder("remove", EarlyReplyMode.visible)
+                    new TextBasedCommandBuilder("remove", "Misc", EarlyReplyMode.visible)
                         .set_description("Timeout remove user")
                         .add_user_option({
                             title: "user",

--- a/src/components/moderation/voice-deputies.ts
+++ b/src/components/moderation/voice-deputies.ts
@@ -19,11 +19,12 @@ export default class VoiceDeputies extends BotComponent {
     override async setup(commands: CommandSetBuilder) {
         this.voice_hotline = await this.utilities.get_channel(this.wheatley.channels.voice_hotline);
         commands.add(
-            new TextBasedCommandBuilder("voice", "Misc", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("voice", EarlyReplyMode.ephemeral)
+                .set_category("Misc")
                 .set_permissions(Discord.PermissionFlagsBits.MoveMembers | Discord.PermissionFlagsBits.MuteMembers)
                 .set_description("Voice moderation")
                 .add_subcommand(
-                    new TextBasedCommandBuilder("give", "Misc", EarlyReplyMode.ephemeral)
+                    new TextBasedCommandBuilder("give", EarlyReplyMode.ephemeral)
                         .set_description("Give voice")
                         .add_user_option({
                             description: "User to receive voice",
@@ -33,7 +34,7 @@ export default class VoiceDeputies extends BotComponent {
                         .set_handler(this.wrap_command_handler(this.on_give_voice.bind(this))),
                 )
                 .add_subcommand(
-                    new TextBasedCommandBuilder("take", "Misc", EarlyReplyMode.ephemeral)
+                    new TextBasedCommandBuilder("take", EarlyReplyMode.ephemeral)
                         .set_description("Take voice")
                         .add_user_option({
                             description: "User to lose voice",
@@ -43,7 +44,7 @@ export default class VoiceDeputies extends BotComponent {
                         .set_handler(this.wrap_command_handler(this.on_take_voice.bind(this))),
                 )
                 .add_subcommand(
-                    new TextBasedCommandBuilder("quarantine", "Misc", EarlyReplyMode.ephemeral)
+                    new TextBasedCommandBuilder("quarantine", EarlyReplyMode.ephemeral)
                         .set_description("Quarantine member")
                         .add_user_option({
                             description: "User to quarantine",

--- a/src/components/moderation/voice-deputies.ts
+++ b/src/components/moderation/voice-deputies.ts
@@ -19,11 +19,11 @@ export default class VoiceDeputies extends BotComponent {
     override async setup(commands: CommandSetBuilder) {
         this.voice_hotline = await this.utilities.get_channel(this.wheatley.channels.voice_hotline);
         commands.add(
-            new TextBasedCommandBuilder("voice", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("voice", "Misc", EarlyReplyMode.ephemeral)
                 .set_permissions(Discord.PermissionFlagsBits.MoveMembers | Discord.PermissionFlagsBits.MuteMembers)
                 .set_description("Voice moderation")
                 .add_subcommand(
-                    new TextBasedCommandBuilder("give", EarlyReplyMode.ephemeral)
+                    new TextBasedCommandBuilder("give", "Misc", EarlyReplyMode.ephemeral)
                         .set_description("Give voice")
                         .add_user_option({
                             description: "User to receive voice",
@@ -33,7 +33,7 @@ export default class VoiceDeputies extends BotComponent {
                         .set_handler(this.wrap_command_handler(this.on_give_voice.bind(this))),
                 )
                 .add_subcommand(
-                    new TextBasedCommandBuilder("take", EarlyReplyMode.ephemeral)
+                    new TextBasedCommandBuilder("take", "Misc", EarlyReplyMode.ephemeral)
                         .set_description("Take voice")
                         .add_user_option({
                             description: "User to lose voice",
@@ -43,7 +43,7 @@ export default class VoiceDeputies extends BotComponent {
                         .set_handler(this.wrap_command_handler(this.on_take_voice.bind(this))),
                 )
                 .add_subcommand(
-                    new TextBasedCommandBuilder("quarantine", EarlyReplyMode.ephemeral)
+                    new TextBasedCommandBuilder("quarantine", "Misc", EarlyReplyMode.ephemeral)
                         .set_description("Quarantine member")
                         .add_user_option({
                             description: "User to quarantine",

--- a/src/components/moderation/warn.ts
+++ b/src/components/moderation/warn.ts
@@ -26,7 +26,8 @@ export default class Warn extends ModerationComponent {
     override async setup(commands: CommandSetBuilder) {
         await super.setup(commands);
         commands.add(
-            new TextBasedCommandBuilder("warn", "Moderation", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("warn", EarlyReplyMode.visible)
+                .set_category("Moderation")
                 .set_permissions(Discord.PermissionFlagsBits.ModerateMembers)
                 .set_description("Warn user")
                 .add_user_option({

--- a/src/components/moderation/warn.ts
+++ b/src/components/moderation/warn.ts
@@ -26,7 +26,7 @@ export default class Warn extends ModerationComponent {
     override async setup(commands: CommandSetBuilder) {
         await super.setup(commands);
         commands.add(
-            new TextBasedCommandBuilder("warn", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("warn", "Moderation", EarlyReplyMode.visible)
                 .set_permissions(Discord.PermissionFlagsBits.ModerateMembers)
                 .set_description("Warn user")
                 .add_user_option({

--- a/src/components/nodistractions.ts
+++ b/src/components/nodistractions.ts
@@ -77,7 +77,7 @@ export default class Nodistractions extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("nodistractions", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("nodistractions", "Utility", EarlyReplyMode.ephemeral)
                 .set_description("Turns on nodistractions")
                 .add_string_option({
                     title: "time",
@@ -88,7 +88,7 @@ export default class Nodistractions extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("removenodistractions", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("removenodistractions", "Utility", EarlyReplyMode.ephemeral)
                 .set_description("Removes nodistractions")
                 .set_handler(this.removenodistractions.bind(this)),
         );

--- a/src/components/nodistractions.ts
+++ b/src/components/nodistractions.ts
@@ -77,7 +77,8 @@ export default class Nodistractions extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("nodistractions", "Utility", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("nodistractions", EarlyReplyMode.ephemeral)
+                .set_category("Utility")
                 .set_description("Turns on nodistractions")
                 .add_string_option({
                     title: "time",
@@ -88,7 +89,8 @@ export default class Nodistractions extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("removenodistractions", "Utility", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("removenodistractions", EarlyReplyMode.ephemeral)
+                .set_category("Utility")
                 .set_description("Removes nodistractions")
                 .set_handler(this.removenodistractions.bind(this)),
         );

--- a/src/components/ping.ts
+++ b/src/components/ping.ts
@@ -17,7 +17,8 @@ export default class Ping extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder(["ping", "wstatus"], "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder(["ping", "wstatus"], EarlyReplyMode.none)
+                .set_category("Misc")
                 .set_description("Ping")
                 .set_handler(this.ping.bind(this)),
         );

--- a/src/components/ping.ts
+++ b/src/components/ping.ts
@@ -17,7 +17,7 @@ export default class Ping extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder(["ping", "wstatus"], EarlyReplyMode.none)
+            new TextBasedCommandBuilder(["ping", "wstatus"], "Misc", EarlyReplyMode.none)
                 .set_description("Ping")
                 .set_handler(this.ping.bind(this)),
         );

--- a/src/components/quote.ts
+++ b/src/components/quote.ts
@@ -39,7 +39,8 @@ type QuoteDescriptor = {
 export default class Quote extends BotComponent {
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder(["quote", "quoteb"], "Utility", EarlyReplyMode.none)
+            new TextBasedCommandBuilder(["quote", "quoteb"], EarlyReplyMode.none)
+                .set_category("Utility")
                 .set_description(["Quote a message", "Quote a block of messages"])
                 .add_string_option({
                     title: "url",

--- a/src/components/quote.ts
+++ b/src/components/quote.ts
@@ -39,7 +39,7 @@ type QuoteDescriptor = {
 export default class Quote extends BotComponent {
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder(["quote", "quoteb"], EarlyReplyMode.none)
+            new TextBasedCommandBuilder(["quote", "quoteb"], "Utility", EarlyReplyMode.none)
                 .set_description(["Quote a message", "Quote a block of messages"])
                 .add_string_option({
                     title: "url",

--- a/src/components/redirect.ts
+++ b/src/components/redirect.ts
@@ -13,7 +13,7 @@ import { format_list } from "../utils/strings.js";
 export default class Redirect extends BotComponent {
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("redirect", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("redirect", "Moderation Utilities", EarlyReplyMode.visible)
                 .set_description("Redirect a conversation")
                 .add_string_option({
                     title: "channel",
@@ -25,7 +25,7 @@ export default class Redirect extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("r", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("r", "Misc", EarlyReplyMode.none)
                 .set_description(
                     `Redirect a conversation from <#${this.wheatley.channels.c_cpp_discussion}> or ` +
                         `<#${this.wheatley.channels.general_discussion}> to a help channel`,

--- a/src/components/redirect.ts
+++ b/src/components/redirect.ts
@@ -25,7 +25,7 @@ export default class Redirect extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("r", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("r", "Moderation Utilities", EarlyReplyMode.none)
                 .set_description(
                     `Redirect a conversation from <#${this.wheatley.channels.c_cpp_discussion}> or ` +
                         `<#${this.wheatley.channels.general_discussion}> to a help channel`,

--- a/src/components/redirect.ts
+++ b/src/components/redirect.ts
@@ -13,7 +13,8 @@ import { format_list } from "../utils/strings.js";
 export default class Redirect extends BotComponent {
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("redirect", "Moderation Utilities", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("redirect", EarlyReplyMode.visible)
+                .set_category("Moderation Utilities")
                 .set_description("Redirect a conversation")
                 .add_string_option({
                     title: "channel",
@@ -25,7 +26,8 @@ export default class Redirect extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("r", "Moderation Utilities", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("r", EarlyReplyMode.none)
+                .set_category("Moderation Utilities")
                 .set_description(
                     `Redirect a conversation from <#${this.wheatley.channels.c_cpp_discussion}> or ` +
                         `<#${this.wheatley.channels.general_discussion}> to a help channel`,

--- a/src/components/restart.ts
+++ b/src/components/restart.ts
@@ -17,7 +17,7 @@ export default class Restart extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("restart", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("restart", "Misc", EarlyReplyMode.none)
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Restart")
                 .set_handler(this.restart.bind(this)),

--- a/src/components/restart.ts
+++ b/src/components/restart.ts
@@ -17,7 +17,8 @@ export default class Restart extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("restart", "Admin utilities", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("restart", EarlyReplyMode.none)
+                .set_category("Admin utilities")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Restart")
                 .set_handler(this.restart.bind(this)),

--- a/src/components/restart.ts
+++ b/src/components/restart.ts
@@ -17,7 +17,7 @@ export default class Restart extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("restart", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("restart", "Admin utilities", EarlyReplyMode.none)
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Restart")
                 .set_handler(this.restart.bind(this)),

--- a/src/components/role-manager.ts
+++ b/src/components/role-manager.ts
@@ -47,14 +47,16 @@ export default class RoleManager extends BotComponent {
         this.staff_member_log = await this.utilities.get_channel(this.wheatley.channels.staff_member_log);
 
         commands.add(
-            new TextBasedCommandBuilder("gimmepink", "Misc", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("gimmepink", EarlyReplyMode.ephemeral)
+                .set_category("Misc")
                 .set_description("Gives pink")
                 .set_slash(false)
                 .set_handler(this.gibpink.bind(this)),
         );
 
         commands.add(
-            new TextBasedCommandBuilder("unpink", "Misc", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("unpink", EarlyReplyMode.ephemeral)
+                .set_category("Misc")
                 .set_description("Takes pink")
                 .set_slash(false)
                 .set_handler(this.unpink.bind(this)),

--- a/src/components/role-manager.ts
+++ b/src/components/role-manager.ts
@@ -47,14 +47,14 @@ export default class RoleManager extends BotComponent {
         this.staff_member_log = await this.utilities.get_channel(this.wheatley.channels.staff_member_log);
 
         commands.add(
-            new TextBasedCommandBuilder("gimmepink", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("gimmepink", "Misc", EarlyReplyMode.ephemeral)
                 .set_description("Gives pink")
                 .set_slash(false)
                 .set_handler(this.gibpink.bind(this)),
         );
 
         commands.add(
-            new TextBasedCommandBuilder("unpink", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("unpink", "Misc", EarlyReplyMode.ephemeral)
                 .set_description("Takes pink")
                 .set_slash(false)
                 .set_handler(this.unpink.bind(this)),

--- a/src/components/shortcuts.ts
+++ b/src/components/shortcuts.ts
@@ -18,26 +18,26 @@ export default class Shortcuts extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("nothingtoseehere", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("nothingtoseehere", "Misc", EarlyReplyMode.none)
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Nothing to see here")
                 .set_handler(this.nothingtoseehere.bind(this)),
         );
 
         commands.add(
-            new TextBasedCommandBuilder(["tryitandsee", "tias"], EarlyReplyMode.none)
+            new TextBasedCommandBuilder(["tryitandsee", "tias"], "Misc", EarlyReplyMode.none)
                 .set_description("Try it and see")
                 .set_handler(this.tryitandsee.bind(this)),
         );
 
         commands.add(
-            new TextBasedCommandBuilder("headbang", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("headbang", "Misc", EarlyReplyMode.none)
                 .set_description("Headbang")
                 .set_handler(this.headbang.bind(this)),
         );
 
         commands.add(
-            new TextBasedCommandBuilder("initgif", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("initgif", "Misc", EarlyReplyMode.none)
                 .set_description("initgif")
                 .set_handler(this.initgif.bind(this)),
         );

--- a/src/components/shortcuts.ts
+++ b/src/components/shortcuts.ts
@@ -18,26 +18,30 @@ export default class Shortcuts extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("nothingtoseehere", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("nothingtoseehere", EarlyReplyMode.none)
+                .set_category("Misc")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Nothing to see here")
                 .set_handler(this.nothingtoseehere.bind(this)),
         );
 
         commands.add(
-            new TextBasedCommandBuilder(["tryitandsee", "tias"], "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder(["tryitandsee", "tias"], EarlyReplyMode.none)
+                .set_category("Misc")
                 .set_description("Try it and see")
                 .set_handler(this.tryitandsee.bind(this)),
         );
 
         commands.add(
-            new TextBasedCommandBuilder("headbang", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("headbang", EarlyReplyMode.none)
+                .set_category("Misc")
                 .set_description("Headbang")
                 .set_handler(this.headbang.bind(this)),
         );
 
         commands.add(
-            new TextBasedCommandBuilder("initgif", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("initgif", EarlyReplyMode.none)
+                .set_category("Misc")
                 .set_description("initgif")
                 .set_handler(this.initgif.bind(this)),
         );

--- a/src/components/snowflake.ts
+++ b/src/components/snowflake.ts
@@ -16,7 +16,7 @@ export default class Snowflake extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("snowflake", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("snowflake", "Utility", EarlyReplyMode.none)
                 .set_description("Snowflake")
                 .add_string_option({
                     title: "input",

--- a/src/components/snowflake.ts
+++ b/src/components/snowflake.ts
@@ -16,7 +16,8 @@ export default class Snowflake extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("snowflake", "Utility", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("snowflake", EarlyReplyMode.none)
+                .set_category("Utility")
                 .set_description("Snowflake")
                 .add_string_option({
                     title: "input",

--- a/src/components/steal.ts
+++ b/src/components/steal.ts
@@ -19,7 +19,7 @@ export default class Steal extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("steal-emojis-message-url", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("steal-emojis-message-url", "Misc", EarlyReplyMode.visible)
                 .set_description("Steal emojis from a message")
                 .add_string_option({
                     title: "url",
@@ -31,7 +31,7 @@ export default class Steal extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("add-emojis-url", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("add-emojis-url", "Misc", EarlyReplyMode.visible)
                 .set_description("Add emojis from a message")
                 .add_string_option({
                     title: "name",
@@ -48,7 +48,7 @@ export default class Steal extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("steal-emojis", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("steal-emojis", "Misc", EarlyReplyMode.visible)
                 .set_description("Steal emojis from a message")
                 .add_string_option({
                     title: "text",

--- a/src/components/steal.ts
+++ b/src/components/steal.ts
@@ -19,7 +19,8 @@ export default class Steal extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("steal-emojis-message-url", "Admin utilities", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("steal-emojis-message-url", EarlyReplyMode.visible)
+                .set_category("Admin utilities")
                 .set_description("Steal emojis from a message")
                 .add_string_option({
                     title: "url",
@@ -31,7 +32,8 @@ export default class Steal extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("add-emojis-url", "Admin utilities", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("add-emojis-url", EarlyReplyMode.visible)
+                .set_category("Admin utilities")
                 .set_description("Add emojis from a message")
                 .add_string_option({
                     title: "name",
@@ -48,7 +50,8 @@ export default class Steal extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("steal-emojis", "Admin utilities", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("steal-emojis", EarlyReplyMode.visible)
+                .set_category("Admin utilities")
                 .set_description("Steal emojis from a message")
                 .add_string_option({
                     title: "text",

--- a/src/components/steal.ts
+++ b/src/components/steal.ts
@@ -19,7 +19,7 @@ export default class Steal extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("steal-emojis-message-url", "Misc", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("steal-emojis-message-url", "Admin utilities", EarlyReplyMode.visible)
                 .set_description("Steal emojis from a message")
                 .add_string_option({
                     title: "url",
@@ -31,7 +31,7 @@ export default class Steal extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("add-emojis-url", "Misc", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("add-emojis-url", "Admin utilities", EarlyReplyMode.visible)
                 .set_description("Add emojis from a message")
                 .add_string_option({
                     title: "name",
@@ -48,7 +48,7 @@ export default class Steal extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("steal-emojis", "Misc", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("steal-emojis", "Admin utilities", EarlyReplyMode.visible)
                 .set_description("Steal emojis from a message")
                 .add_string_option({
                     title: "text",

--- a/src/components/thread-control.ts
+++ b/src/components/thread-control.ts
@@ -14,13 +14,15 @@ export default class ThreadControl extends BotComponent {
     override async setup(commands: CommandSetBuilder) {
         this.rules = await this.utilities.get_channel(this.wheatley.channels.rules);
         commands.add(
-            new TextBasedCommandBuilder("archive", "Thread Control", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("archive", EarlyReplyMode.ephemeral)
+                .set_category("Thread Control")
                 .set_description("Archives the thread")
                 .set_handler(this.archive.bind(this)),
         );
 
         commands.add(
-            new TextBasedCommandBuilder("rename", "Thread Control", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("rename", EarlyReplyMode.ephemeral)
+                .set_category("Thread Control")
                 .set_description("Rename the thread")
                 .add_string_option({
                     title: "name",

--- a/src/components/thread-control.ts
+++ b/src/components/thread-control.ts
@@ -14,13 +14,13 @@ export default class ThreadControl extends BotComponent {
     override async setup(commands: CommandSetBuilder) {
         this.rules = await this.utilities.get_channel(this.wheatley.channels.rules);
         commands.add(
-            new TextBasedCommandBuilder("archive", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("archive", "Thread Control", EarlyReplyMode.ephemeral)
                 .set_description("Archives the thread")
                 .set_handler(this.archive.bind(this)),
         );
 
         commands.add(
-            new TextBasedCommandBuilder("rename", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("rename", "Thread Control", EarlyReplyMode.ephemeral)
                 .set_description("Rename the thread")
                 .add_string_option({
                     title: "name",

--- a/src/components/topic.ts
+++ b/src/components/topic.ts
@@ -18,7 +18,7 @@ export default class Topic extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("topic", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("topic", "Misc", EarlyReplyMode.none)
                 .set_description("Posts the channel topic")
                 .set_handler(this.topic.bind(this)),
         );

--- a/src/components/topic.ts
+++ b/src/components/topic.ts
@@ -18,7 +18,8 @@ export default class Topic extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("topic", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("topic", EarlyReplyMode.none)
+                .set_category("Misc")
                 .set_description("Posts the channel topic")
                 .set_handler(this.topic.bind(this)),
         );

--- a/src/components/wiki.ts
+++ b/src/components/wiki.ts
@@ -349,7 +349,7 @@ export default class Wiki extends BotComponent {
         };
 
         commands.add(
-            new TextBasedCommandBuilder(["wiki", "howto"], EarlyReplyMode.none)
+            new TextBasedCommandBuilder(["wiki", "howto"], "Wiki Articles", EarlyReplyMode.none)
                 .set_description(["Retrieve wiki articles", "Retrieve wiki articles (alternatively /wiki)"])
                 .add_string_option({
                     title: "query",
@@ -371,7 +371,7 @@ export default class Wiki extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder(["wiki-preview", "wp"], EarlyReplyMode.none)
+            new TextBasedCommandBuilder(["wiki-preview", "wp"], "Wiki Articles", EarlyReplyMode.none)
                 .set_slash(false)
                 .set_description("Preview a wiki article")
                 .add_string_option({
@@ -387,7 +387,7 @@ export default class Wiki extends BotComponent {
         for (const [alias, article_name] of this.article_aliases.entries()) {
             const article = this.articles[article_name];
             commands.add(
-                new TextBasedCommandBuilder(alias, EarlyReplyMode.none)
+                new TextBasedCommandBuilder(alias, "Wiki Articles", EarlyReplyMode.none)
                     .set_slash(false)
                     .set_description(article.title)
                     .add_user_option({

--- a/src/components/wiki.ts
+++ b/src/components/wiki.ts
@@ -349,7 +349,8 @@ export default class Wiki extends BotComponent {
         };
 
         commands.add(
-            new TextBasedCommandBuilder(["wiki", "howto"], "Wiki Articles", EarlyReplyMode.none)
+            new TextBasedCommandBuilder(["wiki", "howto"], EarlyReplyMode.none)
+                .set_category("Wiki Articles")
                 .set_description(["Retrieve wiki articles", "Retrieve wiki articles (alternatively /wiki)"])
                 .add_string_option({
                     title: "query",
@@ -371,7 +372,8 @@ export default class Wiki extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder(["wiki-preview", "wp"], "Wiki Articles", EarlyReplyMode.none)
+            new TextBasedCommandBuilder(["wiki-preview", "wp"], EarlyReplyMode.none)
+                .set_category("Wiki Articles")
                 .set_slash(false)
                 .set_description("Preview wiki article markdown")
                 .add_string_option({
@@ -387,7 +389,8 @@ export default class Wiki extends BotComponent {
         for (const [alias, article_name] of this.article_aliases.entries()) {
             const article = this.articles[article_name];
             commands.add(
-                new TextBasedCommandBuilder(alias, "Hidden", EarlyReplyMode.none)
+                new TextBasedCommandBuilder(alias, EarlyReplyMode.none)
+                    .set_category("Hidden")
                     .set_slash(false)
                     .set_description(article.title)
                     .add_user_option({

--- a/src/components/wiki.ts
+++ b/src/components/wiki.ts
@@ -387,7 +387,7 @@ export default class Wiki extends BotComponent {
         for (const [alias, article_name] of this.article_aliases.entries()) {
             const article = this.articles[article_name];
             commands.add(
-                new TextBasedCommandBuilder(alias, "Wiki Articles", EarlyReplyMode.none)
+                new TextBasedCommandBuilder(alias, "Hidden", EarlyReplyMode.none)
                     .set_slash(false)
                     .set_description(article.title)
                     .add_user_option({

--- a/src/components/wiki.ts
+++ b/src/components/wiki.ts
@@ -390,7 +390,8 @@ export default class Wiki extends BotComponent {
             const article = this.articles[article_name];
             commands.add(
                 new TextBasedCommandBuilder(alias, EarlyReplyMode.none)
-                    .set_category("Hidden")
+                    .set_category("Wiki Articles")
+                    .set_alias_of("wiki")
                     .set_slash(false)
                     .set_description(article.title)
                     .add_user_option({

--- a/src/components/wiki.ts
+++ b/src/components/wiki.ts
@@ -373,7 +373,7 @@ export default class Wiki extends BotComponent {
         commands.add(
             new TextBasedCommandBuilder(["wiki-preview", "wp"], "Wiki Articles", EarlyReplyMode.none)
                 .set_slash(false)
-                .set_description("Preview a wiki article")
+                .set_description("Preview wiki article markdown")
                 .add_string_option({
                     title: "content",
                     description: "Content",

--- a/src/modules/tccpp/components/c-help-redirect.ts
+++ b/src/modules/tccpp/components/c-help-redirect.ts
@@ -74,7 +74,7 @@ export default class CHelpRedirect extends BotComponent {
         this.cpp_help_text = await this.utilities.get_channel(this.wheatley.channels.cpp_help_text);
 
         commands.add(
-            new TextBasedCommandBuilder("not-c", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("not-c", "Misc", EarlyReplyMode.none)
                 .set_description("Mark C++ code in the C help channel")
                 .add_user_option({
                     title: "user",
@@ -85,7 +85,7 @@ export default class CHelpRedirect extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("not-cpp", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("not-cpp", "Misc", EarlyReplyMode.none)
                 .set_description("Mark C code in the C++ help channel")
                 .add_user_option({
                     title: "user",

--- a/src/modules/tccpp/components/c-help-redirect.ts
+++ b/src/modules/tccpp/components/c-help-redirect.ts
@@ -74,7 +74,8 @@ export default class CHelpRedirect extends BotComponent {
         this.cpp_help_text = await this.utilities.get_channel(this.wheatley.channels.cpp_help_text);
 
         commands.add(
-            new TextBasedCommandBuilder("not-c", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("not-c", EarlyReplyMode.none)
+                .set_category("Misc")
                 .set_description("Mark C++ code in the C help channel")
                 .add_user_option({
                     title: "user",
@@ -85,7 +86,8 @@ export default class CHelpRedirect extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("not-cpp", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("not-cpp", EarlyReplyMode.none)
+                .set_category("Misc")
                 .set_description("Mark C code in the C++ help channel")
                 .add_user_option({
                     title: "user",

--- a/src/modules/tccpp/components/core-guidelines.ts
+++ b/src/modules/tccpp/components/core-guidelines.ts
@@ -62,7 +62,7 @@ export default class CoreGuidelines extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("guide", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("guide", "References", EarlyReplyMode.none)
                 .set_description("Query C++ Core Guidelines")
                 .add_string_option({
                     title: "query",

--- a/src/modules/tccpp/components/core-guidelines.ts
+++ b/src/modules/tccpp/components/core-guidelines.ts
@@ -62,7 +62,8 @@ export default class CoreGuidelines extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("guide", "References", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("guide", EarlyReplyMode.none)
+                .set_category("References")
                 .set_description("Query C++ Core Guidelines")
                 .add_string_option({
                     title: "query",

--- a/src/modules/tccpp/components/core-guidelines.ts
+++ b/src/modules/tccpp/components/core-guidelines.ts
@@ -62,7 +62,7 @@ export default class CoreGuidelines extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("guide", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("guide", "Misc", EarlyReplyMode.none)
                 .set_description("Query C++ Core Guidelines")
                 .add_string_option({
                     title: "query",

--- a/src/modules/tccpp/components/cppref.ts
+++ b/src/modules/tccpp/components/cppref.ts
@@ -155,7 +155,7 @@ export default class Cppref extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder(["cref", "cppref"], EarlyReplyMode.none)
+            new TextBasedCommandBuilder(["cref", "cppref"], "References", EarlyReplyMode.none)
                 .set_description(["Query C reference pages", "Query C++ reference pages"])
                 .add_string_option({
                     title: "query",

--- a/src/modules/tccpp/components/cppref.ts
+++ b/src/modules/tccpp/components/cppref.ts
@@ -155,7 +155,8 @@ export default class Cppref extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder(["cref", "cppref"], "References", EarlyReplyMode.none)
+            new TextBasedCommandBuilder(["cref", "cppref"], EarlyReplyMode.none)
+                .set_category("References")
                 .set_description(["Query C reference pages", "Query C++ reference pages"])
                 .add_string_option({
                     title: "query",

--- a/src/modules/tccpp/components/forum-control.ts
+++ b/src/modules/tccpp/components/forum-control.ts
@@ -27,13 +27,15 @@ function create_embed(title: string | undefined, color: number, msg: string) {
 export default class ForumControl extends BotComponent {
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder(["solve", "solved", "close"], "Thread Control", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder(["solve", "solved", "close"], EarlyReplyMode.visible)
+                .set_category("Thread Control")
                 .set_description("Close forum post and mark it as solved")
                 .set_handler(this.solve.bind(this)),
         );
 
         commands.add(
-            new TextBasedCommandBuilder(["unsolve", "unsolved", "open"], "Thread Control", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder(["unsolve", "unsolved", "open"], EarlyReplyMode.visible)
+                .set_category("Thread Control")
                 .set_description("Re-open forum post")
                 .set_handler(this.unsolve.bind(this)),
         );

--- a/src/modules/tccpp/components/forum-control.ts
+++ b/src/modules/tccpp/components/forum-control.ts
@@ -27,13 +27,13 @@ function create_embed(title: string | undefined, color: number, msg: string) {
 export default class ForumControl extends BotComponent {
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder(["solve", "solved", "close"], EarlyReplyMode.visible)
+            new TextBasedCommandBuilder(["solve", "solved", "close"], "Thread Control", EarlyReplyMode.visible)
                 .set_description("Close forum post and mark it as solved")
                 .set_handler(this.solve.bind(this)),
         );
 
         commands.add(
-            new TextBasedCommandBuilder(["unsolve", "unsolved", "open"], EarlyReplyMode.visible)
+            new TextBasedCommandBuilder(["unsolve", "unsolved", "open"], "Thread Control", EarlyReplyMode.visible)
                 .set_description("Re-open forum post")
                 .set_handler(this.unsolve.bind(this)),
         );

--- a/src/modules/tccpp/components/man7.ts
+++ b/src/modules/tccpp/components/man7.ts
@@ -96,7 +96,8 @@ export default class Man7 extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("man", "References", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("man", EarlyReplyMode.none)
+                .set_category("References")
                 .set_description("Query linux man pages")
                 .add_string_option({
                     title: "query",

--- a/src/modules/tccpp/components/man7.ts
+++ b/src/modules/tccpp/components/man7.ts
@@ -96,7 +96,7 @@ export default class Man7 extends BotComponent {
 
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("man", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("man", "References", EarlyReplyMode.none)
                 .set_description("Query linux man pages")
                 .add_string_option({
                     title: "query",

--- a/src/modules/tccpp/components/roulette.ts
+++ b/src/modules/tccpp/components/roulette.ts
@@ -33,13 +33,15 @@ export default class Roulette extends BotComponent {
         this.staff_member_log = await this.utilities.get_channel(this.wheatley.channels.staff_member_log);
 
         commands.add(
-            new TextBasedCommandBuilder("roulette", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("roulette", EarlyReplyMode.none)
+                .set_category("Misc")
                 .set_description("roulette")
                 .set_handler(this.roulette.bind(this)),
         );
 
         commands.add(
-            new TextBasedCommandBuilder("leaderboard", "Misc", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("leaderboard", EarlyReplyMode.visible)
+                .set_category("Misc")
                 .set_description("Leaderboard")
                 .set_handler(this.leaderboard.bind(this)),
         );

--- a/src/modules/tccpp/components/roulette.ts
+++ b/src/modules/tccpp/components/roulette.ts
@@ -33,13 +33,13 @@ export default class Roulette extends BotComponent {
         this.staff_member_log = await this.utilities.get_channel(this.wheatley.channels.staff_member_log);
 
         commands.add(
-            new TextBasedCommandBuilder("roulette", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("roulette", "Misc", EarlyReplyMode.none)
                 .set_description("roulette")
                 .set_handler(this.roulette.bind(this)),
         );
 
         commands.add(
-            new TextBasedCommandBuilder("leaderboard", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("leaderboard", "Misc", EarlyReplyMode.visible)
                 .set_description("Leaderboard")
                 .set_handler(this.leaderboard.bind(this)),
         );

--- a/src/modules/tccpp/components/server-suggestion-tracker.ts
+++ b/src/modules/tccpp/components/server-suggestion-tracker.ts
@@ -61,7 +61,8 @@ export default class ServerSuggestionTracker extends BotComponent {
         );
         this.server_suggestions = await this.utilities.get_channel(this.wheatley.channels.server_suggestions);
         commands.add(
-            new TextBasedCommandBuilder("suggestions-dashboard-count", "Admin utilities", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("suggestions-dashboard-count", EarlyReplyMode.visible)
+                .set_category("Admin utilities")
                 .set_description("Server suggestions count")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_handler(this.dashboard_count.bind(this)),

--- a/src/modules/tccpp/components/server-suggestion-tracker.ts
+++ b/src/modules/tccpp/components/server-suggestion-tracker.ts
@@ -61,7 +61,7 @@ export default class ServerSuggestionTracker extends BotComponent {
         );
         this.server_suggestions = await this.utilities.get_channel(this.wheatley.channels.server_suggestions);
         commands.add(
-            new TextBasedCommandBuilder("suggestions-dashboard-count", "Misc", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("suggestions-dashboard-count", "Admin utilities", EarlyReplyMode.visible)
                 .set_description("Server suggestions count")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_handler(this.dashboard_count.bind(this)),

--- a/src/modules/tccpp/components/server-suggestion-tracker.ts
+++ b/src/modules/tccpp/components/server-suggestion-tracker.ts
@@ -61,7 +61,7 @@ export default class ServerSuggestionTracker extends BotComponent {
         );
         this.server_suggestions = await this.utilities.get_channel(this.wheatley.channels.server_suggestions);
         commands.add(
-            new TextBasedCommandBuilder("suggestions-dashboard-count", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("suggestions-dashboard-count", "Misc", EarlyReplyMode.visible)
                 .set_description("Server suggestions count")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_handler(this.dashboard_count.bind(this)),

--- a/src/modules/tccpp/components/skill-role-suggestion.ts
+++ b/src/modules/tccpp/components/skill-role-suggestion.ts
@@ -64,7 +64,8 @@ export default class SkillRoleSuggestion extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("close-skill-suggestion-thread", "Admin utilities", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("close-skill-suggestion-thread", EarlyReplyMode.ephemeral)
+                .set_category("Admin utilities")
                 .set_description("Closes a skill role suggestions thread")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_handler(this.close_thread.bind(this)),

--- a/src/modules/tccpp/components/skill-role-suggestion.ts
+++ b/src/modules/tccpp/components/skill-role-suggestion.ts
@@ -64,7 +64,7 @@ export default class SkillRoleSuggestion extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("close-skill-suggestion-thread", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("close-skill-suggestion-thread", "Misc", EarlyReplyMode.ephemeral)
                 .set_description("Closes a skill role suggestions thread")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_handler(this.close_thread.bind(this)),

--- a/src/modules/tccpp/components/skill-role-suggestion.ts
+++ b/src/modules/tccpp/components/skill-role-suggestion.ts
@@ -64,7 +64,7 @@ export default class SkillRoleSuggestion extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("close-skill-suggestion-thread", "Misc", EarlyReplyMode.ephemeral)
+            new TextBasedCommandBuilder("close-skill-suggestion-thread", "Admin utilities", EarlyReplyMode.ephemeral)
                 .set_description("Closes a skill role suggestions thread")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_handler(this.close_thread.bind(this)),

--- a/src/modules/tccpp/components/starboard.ts
+++ b/src/modules/tccpp/components/starboard.ts
@@ -90,7 +90,7 @@ export default class Starboard extends BotComponent {
         this.staff_flag_log = await this.utilities.get_channel(this.wheatley.channels.staff_flag_log);
 
         commands.add(
-            new TextBasedCommandBuilder("add-negative-emoji", "Misc", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("add-negative-emoji", "Admin utilities", EarlyReplyMode.visible)
                 .set_description("Register a negative emoji")
                 .add_string_option({
                     title: "emojis",
@@ -102,7 +102,7 @@ export default class Starboard extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("add-delete-emoji", "Misc", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("add-delete-emoji", "Admin utilities", EarlyReplyMode.visible)
                 .set_description("Register a delete emoji")
                 .add_string_option({
                     title: "emojis",
@@ -114,7 +114,7 @@ export default class Starboard extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("add-ignored-emoji", "Misc", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("add-ignored-emoji", "Admin utilities", EarlyReplyMode.visible)
                 .set_description("Register an ignored emoji")
                 .add_string_option({
                     title: "emojis",
@@ -126,7 +126,7 @@ export default class Starboard extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("add-repost-emoji", "Misc", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("add-repost-emoji", "Admin utilities", EarlyReplyMode.visible)
                 .set_description("Register a repost emoji")
                 .add_string_option({
                     title: "emojis",
@@ -138,7 +138,7 @@ export default class Starboard extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("list-starboard-config", "Misc", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("list-starboard-config", "Admin utilities", EarlyReplyMode.visible)
                 .set_description("List starboard config")
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_handler(this.list_config.bind(this)),

--- a/src/modules/tccpp/components/starboard.ts
+++ b/src/modules/tccpp/components/starboard.ts
@@ -90,7 +90,7 @@ export default class Starboard extends BotComponent {
         this.staff_flag_log = await this.utilities.get_channel(this.wheatley.channels.staff_flag_log);
 
         commands.add(
-            new TextBasedCommandBuilder("add-negative-emoji", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("add-negative-emoji", "Misc", EarlyReplyMode.visible)
                 .set_description("Register a negative emoji")
                 .add_string_option({
                     title: "emojis",
@@ -102,7 +102,7 @@ export default class Starboard extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("add-delete-emoji", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("add-delete-emoji", "Misc", EarlyReplyMode.visible)
                 .set_description("Register a delete emoji")
                 .add_string_option({
                     title: "emojis",
@@ -114,7 +114,7 @@ export default class Starboard extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("add-ignored-emoji", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("add-ignored-emoji", "Misc", EarlyReplyMode.visible)
                 .set_description("Register an ignored emoji")
                 .add_string_option({
                     title: "emojis",
@@ -126,7 +126,7 @@ export default class Starboard extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("add-repost-emoji", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("add-repost-emoji", "Misc", EarlyReplyMode.visible)
                 .set_description("Register a repost emoji")
                 .add_string_option({
                     title: "emojis",
@@ -138,7 +138,7 @@ export default class Starboard extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("list-starboard-config", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("list-starboard-config", "Misc", EarlyReplyMode.visible)
                 .set_description("List starboard config")
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_handler(this.list_config.bind(this)),

--- a/src/modules/tccpp/components/starboard.ts
+++ b/src/modules/tccpp/components/starboard.ts
@@ -90,7 +90,8 @@ export default class Starboard extends BotComponent {
         this.staff_flag_log = await this.utilities.get_channel(this.wheatley.channels.staff_flag_log);
 
         commands.add(
-            new TextBasedCommandBuilder("add-negative-emoji", "Admin utilities", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("add-negative-emoji", EarlyReplyMode.visible)
+                .set_category("Admin utilities")
                 .set_description("Register a negative emoji")
                 .add_string_option({
                     title: "emojis",
@@ -102,7 +103,8 @@ export default class Starboard extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("add-delete-emoji", "Admin utilities", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("add-delete-emoji", EarlyReplyMode.visible)
+                .set_category("Admin utilities")
                 .set_description("Register a delete emoji")
                 .add_string_option({
                     title: "emojis",
@@ -114,7 +116,8 @@ export default class Starboard extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("add-ignored-emoji", "Admin utilities", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("add-ignored-emoji", EarlyReplyMode.visible)
+                .set_category("Admin utilities")
                 .set_description("Register an ignored emoji")
                 .add_string_option({
                     title: "emojis",
@@ -126,7 +129,8 @@ export default class Starboard extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("add-repost-emoji", "Admin utilities", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("add-repost-emoji", EarlyReplyMode.visible)
+                .set_category("Admin utilities")
                 .set_description("Register a repost emoji")
                 .add_string_option({
                     title: "emojis",
@@ -138,7 +142,8 @@ export default class Starboard extends BotComponent {
         );
 
         commands.add(
-            new TextBasedCommandBuilder("list-starboard-config", "Admin utilities", EarlyReplyMode.visible)
+            new TextBasedCommandBuilder("list-starboard-config", EarlyReplyMode.visible)
+                .set_category("Admin utilities")
                 .set_description("List starboard config")
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_handler(this.list_config.bind(this)),

--- a/src/modules/tccpp/components/the-button.ts
+++ b/src/modules/tccpp/components/the-button.ts
@@ -86,28 +86,28 @@ export default class TheButton extends BotComponent {
         this.the_button_channel = await this.utilities.get_channel(this.wheatley.channels.the_button);
 
         commands.add(
-            new TextBasedCommandBuilder("wsetupthebutton", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("wsetupthebutton", "Admin utilities", EarlyReplyMode.none)
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_description("Setup The Button here")
                 .set_slash(false)
                 .set_handler(this.button_setup.bind(this)),
         );
         commands.add(
-            new TextBasedCommandBuilder("wresetthebutton", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("wresetthebutton", "Admin utilities", EarlyReplyMode.none)
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_description("Reset The Button")
                 .set_slash(false)
                 .set_handler(this.button_reset.bind(this)),
         );
         commands.add(
-            new TextBasedCommandBuilder("wresetthebuttonscoreboard", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("wresetthebuttonscoreboard", "Admin utilities", EarlyReplyMode.none)
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_description("Reset The Button scoreboard")
                 .set_slash(false)
                 .set_handler(this.button_reset_scoreboard.bind(this)),
         );
         commands.add(
-            new TextBasedCommandBuilder("wadjustscores", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("wadjustscores", "Admin utilities", EarlyReplyMode.none)
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_description("Adjust The Button scores")
                 .set_slash(false)

--- a/src/modules/tccpp/components/the-button.ts
+++ b/src/modules/tccpp/components/the-button.ts
@@ -86,28 +86,32 @@ export default class TheButton extends BotComponent {
         this.the_button_channel = await this.utilities.get_channel(this.wheatley.channels.the_button);
 
         commands.add(
-            new TextBasedCommandBuilder("wsetupthebutton", "Admin utilities", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("wsetupthebutton", EarlyReplyMode.none)
+                .set_category("Admin utilities")
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_description("Setup The Button here")
                 .set_slash(false)
                 .set_handler(this.button_setup.bind(this)),
         );
         commands.add(
-            new TextBasedCommandBuilder("wresetthebutton", "Admin utilities", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("wresetthebutton", EarlyReplyMode.none)
+                .set_category("Admin utilities")
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_description("Reset The Button")
                 .set_slash(false)
                 .set_handler(this.button_reset.bind(this)),
         );
         commands.add(
-            new TextBasedCommandBuilder("wresetthebuttonscoreboard", "Admin utilities", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("wresetthebuttonscoreboard", EarlyReplyMode.none)
+                .set_category("Admin utilities")
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_description("Reset The Button scoreboard")
                 .set_slash(false)
                 .set_handler(this.button_reset_scoreboard.bind(this)),
         );
         commands.add(
-            new TextBasedCommandBuilder("wadjustscores", "Admin utilities", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("wadjustscores", EarlyReplyMode.none)
+                .set_category("Admin utilities")
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_description("Adjust The Button scores")
                 .set_slash(false)

--- a/src/modules/tccpp/components/the-button.ts
+++ b/src/modules/tccpp/components/the-button.ts
@@ -86,28 +86,28 @@ export default class TheButton extends BotComponent {
         this.the_button_channel = await this.utilities.get_channel(this.wheatley.channels.the_button);
 
         commands.add(
-            new TextBasedCommandBuilder("wsetupthebutton", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("wsetupthebutton", "Misc", EarlyReplyMode.none)
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_description("Setup The Button here")
                 .set_slash(false)
                 .set_handler(this.button_setup.bind(this)),
         );
         commands.add(
-            new TextBasedCommandBuilder("wresetthebutton", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("wresetthebutton", "Misc", EarlyReplyMode.none)
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_description("Reset The Button")
                 .set_slash(false)
                 .set_handler(this.button_reset.bind(this)),
         );
         commands.add(
-            new TextBasedCommandBuilder("wresetthebuttonscoreboard", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("wresetthebuttonscoreboard", "Misc", EarlyReplyMode.none)
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_description("Reset The Button scoreboard")
                 .set_slash(false)
                 .set_handler(this.button_reset_scoreboard.bind(this)),
         );
         commands.add(
-            new TextBasedCommandBuilder("wadjustscores", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("wadjustscores", "Misc", EarlyReplyMode.none)
                 .set_permissions(Discord.PermissionFlagsBits.Administrator)
                 .set_description("Adjust The Button scores")
                 .set_slash(false)

--- a/src/modules/tccpp/components/utility-tools.ts
+++ b/src/modules/tccpp/components/utility-tools.ts
@@ -15,7 +15,8 @@ import { Synopsinator } from "../../../utils/synopsis.js";
 export default class UtilityTools extends BotComponent {
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("count", "Misc", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("count", EarlyReplyMode.none)
+                .set_category("Misc")
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Count")
                 .add_number_option({

--- a/src/modules/tccpp/components/utility-tools.ts
+++ b/src/modules/tccpp/components/utility-tools.ts
@@ -15,7 +15,7 @@ import { Synopsinator } from "../../../utils/synopsis.js";
 export default class UtilityTools extends BotComponent {
     override async setup(commands: CommandSetBuilder) {
         commands.add(
-            new TextBasedCommandBuilder("count", EarlyReplyMode.none)
+            new TextBasedCommandBuilder("count", "Misc", EarlyReplyMode.none)
                 .set_permissions(Discord.PermissionFlagsBits.BanMembers)
                 .set_description("Count")
                 .add_number_option({

--- a/src/wheatley.ts
+++ b/src/wheatley.ts
@@ -684,6 +684,10 @@ export class Wheatley {
         return this.command_handler.get_command(command);
     }
 
+    get_all_commands() {
+        return this.command_handler.get_all_commands();
+    }
+
     register_non_command_bot_reply(trigger: Discord.Message, message: Discord.Message) {
         this.command_handler.register_non_command_bot_reply(trigger, message);
     }


### PR DESCRIPTION
This PR reworks the help command to get a list of commands from wheatley rather than relying on a hard-coded set of commands, thanks to claude.

Closes #174