### PR TITLE
Update permissions of notes to allow vc mods to interact with the notes system

### DIFF
--- a/src/modules/wheatley/components/moderation/note.ts
+++ b/src/modules/wheatley/components/moderation/note.ts
@@ -34,7 +34,7 @@ export default class Note extends ModerationComponent {
         commands.add(
             new TextBasedCommandBuilder("note", EarlyReplyMode.ephemeral)
                 .set_category("Moderation")
-                .set_permissions(Discord.PermissionFlagsBits.ModerateMembers)
+                .set_permissions(Discord.PermissionFlagsBits.MuteMembers)
                 .set_description("Enter note in modlogs")
                 .add_user_option({
                     title: "user",


### PR DESCRIPTION
Updated the permissions on the notes system to enable vc mods to be able to actually use notes.

This pr has been made really to also enable discussion on the idea.