### PR TITLE
Clean up RoleManager

### DIFF
--- a/src/role-map.ts
+++ b/src/role-map.ts
@@ -18,21 +18,17 @@ export function define_roles<const T extends Record<string, { id: string; name?:
 
 type keyed_role_id = named_id & { key: string };
 
-export function role_map<const T extends readonly keyed_role_id[]>(
-    wheatley: Wheatley,
-    ...role_ids: T
-): { resolve(): void } & { [E in T[number] as E["key" | "id"]]: Discord.Role } {
+export function role_map<const T extends readonly keyed_role_id[]>(wheatley: Wheatley, ...role_ids: T) {
     const target: Record<string, unknown> = {};
     let resolved = false;
     const resolve = () => {
         const utilities = new BotUtilities(wheatley);
         for (const role_id of role_ids) {
-            const role = utilities.resolve_role(role_id);
-            target[role_id.key] = role;
-            target[role.id] = role;
+            target[role_id.key] = utilities.resolve_role(role_id);
         }
         resolved = true;
     };
+    const values = () => Object.values(target);
     return new Proxy(target, {
         get(obj, prop) {
             if (prop === "resolve") {
@@ -41,7 +37,10 @@ export function role_map<const T extends readonly keyed_role_id[]>(
             if (typeof prop === "string") {
                 assert(resolved, `Role binding accessed before resolution (key: ${prop})`);
             }
+            if (prop === "values") {
+                return values;
+            }
             return Reflect.get(obj, prop);
         },
-    }) as { resolve(): void } & { [E in T[number] as E["key" | "id"]]: Discord.Role };
+    }) as { resolve(): void; values(): Iterable<Discord.Role> } & { [E in T[number] as E["key"]]: Discord.Role };
 }


### PR DESCRIPTION
Cleans up `RoleManager` and replaces a few more hardcoded roles with the following logic:
* we do not restore the everyone role
* we do not restore any role whose permissions differ from the everyone role (non-vanity roles, roles with elevated permissions, etc.)
* we do not restore managed roles (server booster, linked github, bot roles, etc.)