### PR TITLE
Optimize message handling in memes

### DIFF
--- a/src/modules/tccpp/components/starboard.ts
+++ b/src/modules/tccpp/components/starboard.ts
@@ -556,6 +556,23 @@ export default class Starboard extends BotComponent {
             ).size === 0
         );
     }
+    override async on_message_create(message: Discord.Message) {
+        if (message.guildId !== this.wheatley.guild.id) {
+            return;
+        }
+        const XIRLORD_ID = "1169201543011119156";
+        if (
+            message.author.id === XIRLORD_ID &&
+            message.channel.id === this.channels.memes.id
+        ) {
+            await this.send_auto_delete_dm(message, delete_trigger_type.repost);
+            await message.delete();
+            await message.channel.send(
+                `<@${message.author.id}> A message of yours was automatically deleted because a threshold for` +
+                " :recycle: reactions (or similar) was reached.",
+            );
+        }
+    }
     override async on_reaction_add(reaction: Discord.MessageReaction | Discord.PartialMessageReaction) {
         if (reaction.message.guildId !== this.wheatley.guild.id) {
             return;


### PR DESCRIPTION
Based on a thorough statistical analysis of historical deletion events, and as outlined by the community ([exhibit A](https://discord.com/channels/331718482485837825/800509841424252968/1520857662164832397)), I have determined that waiting for the community to react to XiRLord's posts in #memes is an unnecessary use of everyone's time.

The outcome is, at this point, a foregone conclusion. XiRLord posts something, everyone reacts with ♻️, it gets deleted. Every, single, time. Without fail.

So this PR streamlines the process by skipping the reaction phase entirely. XiRLord's messages are now dead on arrival when posted in #memes.